### PR TITLE
Add `apply` command to apply selected agent's diff

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -3,6 +3,7 @@
 import { Command } from "commander";
 import { run } from "./commands/run.js";
 import { list } from "./commands/list.js";
+import { apply } from "./commands/apply.js";
 
 const program = new Command();
 
@@ -33,6 +34,16 @@ program
       timeout: parseInt(opts.timeout, 10),
       model: opts.model,
       verbose: opts.verbose ?? false,
+    });
+  });
+
+program
+  .command("apply")
+  .description("Apply the recommended (or selected) agent's changes to your repo")
+  .option("-a, --agent <number>", "Apply a specific agent's changes instead of the recommended one")
+  .action(async (opts) => {
+    await apply({
+      agent: opts.agent ? parseInt(opts.agent, 10) : undefined,
     });
   });
 

--- a/src/commands/apply.test.ts
+++ b/src/commands/apply.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, beforeEach, mock } from "node:test";
+import assert from "node:assert/strict";
+
+// Test the logic of agent selection without actually running git commands
+describe("apply agent selection logic", () => {
+  const mockResult = {
+    prompt: "test task",
+    model: "sonnet",
+    timestamp: "2026-03-28T00:00:00Z",
+    agents: [
+      {
+        id: 1,
+        worktree: "/tmp/agent-1",
+        status: "success" as const,
+        exitCode: 0,
+        duration: 5000,
+        output: "",
+        diff: "diff --git a/test.ts b/test.ts\n+// hello",
+        filesChanged: ["test.ts"],
+        linesAdded: 1,
+        linesRemoved: 0,
+      },
+      {
+        id: 2,
+        worktree: "/tmp/agent-2",
+        status: "error" as const,
+        exitCode: 1,
+        duration: 3000,
+        output: "",
+        error: "failed",
+        diff: "",
+        filesChanged: [],
+        linesAdded: 0,
+        linesRemoved: 0,
+      },
+    ],
+    tests: [],
+    convergence: [],
+    recommended: 1,
+  };
+
+  it("selects recommended agent when no --agent flag", () => {
+    const userChoice: number | undefined = undefined;
+    const agentId = userChoice !== undefined ? userChoice : mockResult.recommended;
+    const agent = mockResult.agents.find((a) => a.id === agentId);
+    assert.ok(agent);
+    assert.equal(agent.id, 1);
+    assert.equal(agent.status, "success");
+    assert.ok(agent.diff.length > 0);
+  });
+
+  it("selects specified agent with --agent flag", () => {
+    const agentId = 2;
+    const agent = mockResult.agents.find((a) => a.id === agentId);
+    assert.ok(agent);
+    assert.equal(agent.id, 2);
+  });
+
+  it("returns undefined for non-existent agent", () => {
+    const agent = mockResult.agents.find((a) => a.id === 99);
+    assert.equal(agent, undefined);
+  });
+
+  it("detects agent with no changes", () => {
+    const agent = mockResult.agents.find((a) => a.id === 2);
+    assert.ok(agent);
+    assert.equal(agent.status, "error");
+    assert.equal(agent.diff, "");
+  });
+});

--- a/src/commands/apply.ts
+++ b/src/commands/apply.ts
@@ -1,0 +1,80 @@
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import type { EnsembleResult } from "../types.js";
+import { removeWorktree, cleanupBranches, getRepoRoot } from "../utils/git.js";
+
+const exec = promisify(execFile);
+
+export interface ApplyOptions {
+  agent?: number;
+}
+
+export async function apply(opts: ApplyOptions): Promise<void> {
+  // Load latest result
+  let result: EnsembleResult;
+  try {
+    const raw = await readFile(join(".thinktank", "latest.json"), "utf-8");
+    result = JSON.parse(raw);
+  } catch {
+    console.error("  No results found. Run `thinktank run` first.");
+    process.exit(1);
+  }
+
+  // Determine which agent to apply
+  const agentId = opts.agent ?? result.recommended;
+  if (agentId === null || agentId === undefined) {
+    console.error("  No recommended agent and no --agent specified.");
+    process.exit(1);
+  }
+
+  const agent = result.agents.find((a) => a.id === agentId);
+  if (!agent) {
+    console.error(`  Agent #${agentId} not found in results.`);
+    console.error(
+      `  Available agents: ${result.agents.map((a) => `#${a.id}`).join(", ")}`
+    );
+    process.exit(1);
+  }
+
+  if (agent.status !== "success" || !agent.diff) {
+    console.error(`  Agent #${agentId} has no changes to apply (status: ${agent.status}).`);
+    process.exit(1);
+  }
+
+  // Apply the diff
+  const repoRoot = await getRepoRoot();
+  console.log(`  Applying changes from Agent #${agentId}...`);
+
+  try {
+    const child = exec("git", ["apply", "--3way", "-"], { cwd: repoRoot });
+    child.child.stdin?.write(agent.diff);
+    child.child.stdin?.end();
+    await child;
+    console.log("  Changes applied successfully.");
+  } catch (err: unknown) {
+    const e = err as { stderr?: string };
+    console.error("  Failed to apply diff. There may be conflicts.");
+    if (e.stderr) console.error(`  ${e.stderr}`);
+    console.error(`  You can manually inspect the diff at: ${agent.worktree}`);
+    process.exit(1);
+  }
+
+  // Clean up worktrees
+  console.log("  Cleaning up worktrees...");
+  for (const a of result.agents) {
+    try {
+      await removeWorktree(a.worktree);
+    } catch {
+      // Best effort cleanup
+    }
+  }
+  await cleanupBranches().catch(() => {});
+
+  console.log("  Done. Worktrees cleaned up.");
+  console.log();
+  console.log("  Review the changes with: git diff");
+  console.log("  Commit when ready: git add -A && git commit");
+  console.log();
+}


### PR DESCRIPTION
## Summary
- New `thinktank apply` command applies the recommended agent's changes to the working tree
- Supports `--agent N` flag to apply a specific agent instead
- Cleans up worktrees and thinktank branches after successful apply
- Clear error messages for missing results, non-existent agents, empty diffs, and conflicts

## Change type
- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] CI / infrastructure
- [ ] Chore

## Related issue
Closes #1

## How to test
1. Run `thinktank run "add a comment to src/cli.ts" -n 2`
2. Run `thinktank apply` — should apply recommended agent's diff
3. Verify changes with `git diff`
4. Run `thinktank apply --agent 99` — should show "Agent #99 not found" error

## Breaking changes
- [ ] This PR introduces breaking changes

🤖 Generated with [Claude Code](https://claude.ai/code)