### PR TITLE
Add Biome linting, formatting, and developer experience setup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+# Required: Anthropic API key (used by Claude Code CLI)
+# Get one at https://console.anthropic.com/
+ANTHROPIC_API_KEY=sk-ant-...

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,9 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Lint
+        run: npm run lint
+
       - name: Build
         run: npm run build
 

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,5 @@
+{
+  "recommendations": [
+    "biomejs.biome"
+  ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,7 @@
+{
+  "editor.defaultFormatter": "biomejs.biome",
+  "editor.formatOnSave": true,
+  "[typescript]": {
+    "editor.defaultFormatter": "biomejs.biome"
+  }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,30 @@
+# thinktank — AI Coding Instructions
+
+## What this project is
+thinktank is an ensemble AI coding tool. It runs N parallel Claude Code agents on the same task in isolated git worktrees, then selects the best result via test execution and convergence analysis.
+
+## Architecture
+- `src/cli.ts` — CLI entry point (commander)
+- `src/commands/` — CLI commands (run, apply, list)
+- `src/runners/` — Agent runners (claude-code, future: cursor, copilot)
+- `src/scoring/` — Convergence analysis and recommendation
+- `src/utils/` — Git operations, terminal display
+
+## Code conventions
+- TypeScript strict mode, no `any` types
+- Use node:test for testing (not jest/vitest)
+- Error messages must be actionable: tell the user what to do
+- Keep functions small and focused
+- Prefer composition over inheritance
+
+## Commands
+- `npm run build` — compile TypeScript
+- `npm test` — run all tests
+- `npm run lint` — check with Biome
+- `npm run lint:fix` — auto-fix lint issues
+- `npx tsx src/cli.ts` — run CLI in dev mode
+
+## PR process
+- One issue per PR, always reference the issue
+- Branch naming: `issue-N-short-description`
+- Build + lint + tests must pass before merging

--- a/biome.json
+++ b/biome.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "https://biomejs.dev/schemas/2.4.9/schema.json",
+  "linter": {
+    "enabled": true,
+    "rules": {
+      "recommended": true,
+      "correctness": {
+        "noUnusedImports": "warn"
+      }
+    }
+  },
+  "formatter": {
+    "enabled": true,
+    "indentStyle": "space",
+    "indentWidth": 2,
+    "lineWidth": 100
+  },
+  "assist": {
+    "actions": {
+      "source": {
+        "organizeImports": {
+          "level": "on"
+        }
+      }
+    }
+  },
+  "files": {
+    "includes": ["src/**"]
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,187 @@
 {
   "name": "thinktank",
-  "version": "1.0.0",
+  "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "thinktank",
-      "version": "1.0.0",
-      "license": "ISC",
+      "version": "0.1.0",
+      "license": "MIT",
       "dependencies": {
+        "commander": "^14.0.3"
+      },
+      "bin": {
+        "thinktank": "dist/cli.js"
+      },
+      "devDependencies": {
+        "@biomejs/biome": "^2.4.9",
         "@types/node": "^25.5.0",
-        "commander": "^14.0.3",
         "tsx": "^4.21.0",
         "typescript": "^6.0.2"
+      }
+    },
+    "node_modules/@biomejs/biome": {
+      "version": "2.4.9",
+      "resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.4.9.tgz",
+      "integrity": "sha512-wvZW92FrwitTcacvCBT8xdAbfbxWfDLwjYMmU3djjqQTh7Ni4ZdiWIT/x5VcZ+RQuxiKzIOzi5D+dcyJDFZMsA==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "bin": {
+        "biome": "bin/biome"
+      },
+      "engines": {
+        "node": ">=14.21.3"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/biome"
+      },
+      "optionalDependencies": {
+        "@biomejs/cli-darwin-arm64": "2.4.9",
+        "@biomejs/cli-darwin-x64": "2.4.9",
+        "@biomejs/cli-linux-arm64": "2.4.9",
+        "@biomejs/cli-linux-arm64-musl": "2.4.9",
+        "@biomejs/cli-linux-x64": "2.4.9",
+        "@biomejs/cli-linux-x64-musl": "2.4.9",
+        "@biomejs/cli-win32-arm64": "2.4.9",
+        "@biomejs/cli-win32-x64": "2.4.9"
+      }
+    },
+    "node_modules/@biomejs/cli-darwin-arm64": {
+      "version": "2.4.9",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-2.4.9.tgz",
+      "integrity": "sha512-d5G8Gf2RpH5pYwiHLPA+UpG3G9TLQu4WM+VK6sfL7K68AmhcEQ9r+nkj/DvR/GYhYox6twsHUtmWWWIKfcfQQA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-darwin-x64": {
+      "version": "2.4.9",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-2.4.9.tgz",
+      "integrity": "sha512-LNCLNgqDMG7BLdc3a8aY/dwKPK7+R8/JXJoXjCvZh2gx8KseqBdFDKbhrr7HCWF8SzNhbTaALhTBoh/I6rf9lA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-linux-arm64": {
+      "version": "2.4.9",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-2.4.9.tgz",
+      "integrity": "sha512-4adnkAUi6K4C/emPRgYznMOcLlUqZdXWM6aIui4VP4LraE764g6Q4YguygnAUoxKjKIXIWPteKMgRbN0wsgwcg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-linux-arm64-musl": {
+      "version": "2.4.9",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.4.9.tgz",
+      "integrity": "sha512-8RCww5xnPn2wpK4L/QDGDOW0dq80uVWfppPxHIUg6mOs9B6gRmqPp32h1Ls3T8GnW8Wo5A8u7vpTwz4fExN+sw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-linux-x64": {
+      "version": "2.4.9",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-2.4.9.tgz",
+      "integrity": "sha512-L10na7POF0Ks/cgLFNF1ZvIe+X4onLkTi5oP9hY+Rh60Q+7fWzKDDCeGyiHUFf1nGIa9dQOOUPGe2MyYg8nMSQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-linux-x64-musl": {
+      "version": "2.4.9",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-2.4.9.tgz",
+      "integrity": "sha512-5TD+WS9v5vzXKzjetF0hgoaNFHMcpQeBUwKKVi3JbG1e9UCrFuUK3Gt185fyTzvRdwYkJJEMqglRPjmesmVv4A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-win32-arm64": {
+      "version": "2.4.9",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-2.4.9.tgz",
+      "integrity": "sha512-aDZr0RBC3sMGJOU10BvG7eZIlWLK/i51HRIfScE2lVhfts2dQTreowLiJJd+UYg/tHKxS470IbzpuKmd0MiD6g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-win32-x64": {
+      "version": "2.4.9",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-2.4.9.tgz",
+      "integrity": "sha512-NS4g/2G9SoQ4ktKtz31pvyc/rmgzlcIDCGU/zWbmHJAqx6gcRj2gj5Q/guXhoWTzCUaQZDIqiCQXHS7BcGYc0w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -22,6 +191,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -38,6 +208,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -54,6 +225,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -70,6 +242,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -86,6 +259,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -102,6 +276,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -118,6 +293,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -134,6 +310,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -150,6 +327,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -166,6 +344,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -182,6 +361,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -198,6 +378,7 @@
       "cpu": [
         "loong64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -214,6 +395,7 @@
       "cpu": [
         "mips64el"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -230,6 +412,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -246,6 +429,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -262,6 +446,7 @@
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -278,6 +463,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -294,6 +480,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -310,6 +497,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -326,6 +514,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -342,6 +531,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -358,6 +548,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -374,6 +565,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -390,6 +582,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -406,6 +599,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -422,6 +616,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -435,6 +630,7 @@
       "version": "25.5.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-25.5.0.tgz",
       "integrity": "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.18.0"
@@ -453,6 +649,7 @@
       "version": "0.27.4",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.4.tgz",
       "integrity": "sha512-Rq4vbHnYkK5fws5NF7MYTU68FPRE1ajX7heQ/8QXXWqNgqqJ/GkmmyxIzUnf2Sr/bakf8l54716CcMGHYhMrrQ==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {
@@ -494,6 +691,7 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -508,6 +706,7 @@
       "version": "4.13.7",
       "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.13.7.tgz",
       "integrity": "sha512-7tN6rFgBlMgpBML5j8typ92BKFi2sFQvIdpAqLA2beia5avZDrMs0FLZiM5etShWq5irVyGcGMEA1jcDaK7A/Q==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "resolve-pkg-maps": "^1.0.0"
@@ -520,6 +719,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
       "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
@@ -529,6 +729,7 @@
       "version": "4.21.0",
       "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
       "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "esbuild": "~0.27.0",
@@ -548,6 +749,7 @@
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.2.tgz",
       "integrity": "sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ==",
+      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -561,6 +763,7 @@
       "version": "7.18.2",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
       "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+      "dev": true,
       "license": "MIT"
     }
   }

--- a/package.json
+++ b/package.json
@@ -9,15 +9,26 @@
   "scripts": {
     "build": "tsc",
     "dev": "tsx src/cli.ts",
-    "test": "tsx --test src/**/*.test.ts"
+    "test": "tsx --test src/**/*.test.ts",
+    "lint": "biome check src/",
+    "lint:fix": "biome check --write src/",
+    "format": "biome format --write src/"
   },
-  "keywords": ["ai", "coding", "ensemble", "claude", "claude-code", "consensus"],
+  "keywords": [
+    "ai",
+    "coding",
+    "ensemble",
+    "claude",
+    "claude-code",
+    "consensus"
+  ],
   "author": "",
   "license": "MIT",
   "dependencies": {
     "commander": "^14.0.3"
   },
   "devDependencies": {
+    "@biomejs/biome": "^2.4.9",
     "@types/node": "^25.5.0",
     "tsx": "^4.21.0",
     "typescript": "^6.0.2"

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,16 +1,16 @@
 #!/usr/bin/env node
 
 import { Command } from "commander";
-import { run } from "./commands/run.js";
-import { list } from "./commands/list.js";
 import { apply } from "./commands/apply.js";
+import { list } from "./commands/list.js";
+import { run } from "./commands/run.js";
 
 const program = new Command();
 
 program
   .name("thinktank")
   .description(
-    "Ensemble AI coding — run N parallel agents on the same task, select the best result"
+    "Ensemble AI coding — run N parallel agents on the same task, select the best result",
   )
   .version("0.1.0");
 
@@ -19,10 +19,7 @@ program
   .description("Run a task with N parallel Claude Code agents")
   .argument("<prompt>", "The coding task to perform")
   .option("-n, --attempts <number>", "Number of parallel attempts", "3")
-  .option(
-    "-t, --test-cmd <command>",
-    "Test command to verify results (e.g., 'npm test')"
-  )
+  .option("-t, --test-cmd <command>", "Test command to verify results (e.g., 'npm test')")
   .option("--timeout <seconds>", "Timeout per agent in seconds", "300")
   .option("--model <model>", "Claude model to use", "sonnet")
   .option("--verbose", "Show detailed output from each agent")

--- a/src/commands/apply.test.ts
+++ b/src/commands/apply.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, beforeEach, mock } from "node:test";
 import assert from "node:assert/strict";
+import { beforeEach, describe, it, mock } from "node:test";
 
 // Test the logic of agent selection without actually running git commands
 describe("apply agent selection logic", () => {

--- a/src/commands/apply.ts
+++ b/src/commands/apply.ts
@@ -1,9 +1,9 @@
+import { execFile } from "node:child_process";
 import { readFile } from "node:fs/promises";
 import { join } from "node:path";
-import { execFile } from "node:child_process";
 import { promisify } from "node:util";
 import type { EnsembleResult } from "../types.js";
-import { removeWorktree, cleanupBranches, getRepoRoot } from "../utils/git.js";
+import { cleanupBranches, getRepoRoot, removeWorktree } from "../utils/git.js";
 
 const exec = promisify(execFile);
 
@@ -32,9 +32,7 @@ export async function apply(opts: ApplyOptions): Promise<void> {
   const agent = result.agents.find((a) => a.id === agentId);
   if (!agent) {
     console.error(`  Agent #${agentId} not found in results.`);
-    console.error(
-      `  Available agents: ${result.agents.map((a) => `#${a.id}`).join(", ")}`
-    );
+    console.error(`  Available agents: ${result.agents.map((a) => `#${a.id}`).join(", ")}`);
     process.exit(1);
   }
 

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -1,15 +1,11 @@
-import type { RunOptions, AgentResult, EnsembleResult } from "../types.js";
-import { createWorktree, removeWorktree, cleanupBranches } from "../utils/git.js";
-import { runClaudeAgent } from "../runners/claude-code.js";
-import { runTests } from "../scoring/test-runner.js";
-import { analyzeConvergence, recommend } from "../scoring/convergence.js";
-import {
-  displayHeader,
-  displayResults,
-  displayApplyInstructions,
-} from "../utils/display.js";
-import { writeFile, mkdir } from "node:fs/promises";
+import { mkdir, writeFile } from "node:fs/promises";
 import { join } from "node:path";
+import { runClaudeAgent } from "../runners/claude-code.js";
+import { analyzeConvergence, recommend } from "../scoring/convergence.js";
+import { runTests } from "../scoring/test-runner.js";
+import type { AgentResult, EnsembleResult, RunOptions } from "../types.js";
+import { displayApplyInstructions, displayHeader, displayResults } from "../utils/display.js";
+import { cleanupBranches, createWorktree, removeWorktree } from "../utils/git.js";
 
 export async function run(opts: RunOptions): Promise<void> {
   displayHeader(opts.prompt, opts.attempts, opts.model);
@@ -33,7 +29,7 @@ export async function run(opts: RunOptions): Promise<void> {
   console.log();
 
   const agentPromises = worktrees.map(({ id, path }) =>
-    runClaudeAgent(id, opts.prompt, path, opts.model, opts.timeout, opts.verbose)
+    runClaudeAgent(id, opts.prompt, path, opts.model, opts.timeout, opts.verbose),
   );
 
   const agents: AgentResult[] = await Promise.all(agentPromises);
@@ -43,19 +39,18 @@ export async function run(opts: RunOptions): Promise<void> {
     const icon = agent.status === "success" ? "✓" : agent.status === "timeout" ? "⏱" : "✗";
     const files = agent.filesChanged.length;
     console.log(
-      `    Agent #${agent.id}: ${icon} ${agent.status} — ${files} files changed in ${Math.round(agent.duration / 1000)}s`
+      `    Agent #${agent.id}: ${icon} ${agent.status} — ${files} files changed in ${Math.round(agent.duration / 1000)}s`,
     );
   }
   console.log();
 
   // Phase 3: Run tests (if test command provided)
-  let testResults: Array<{ agentId: number; passed: boolean; output: string; exitCode: number }> = [];
+  let testResults: Array<{ agentId: number; passed: boolean; output: string; exitCode: number }> =
+    [];
 
   if (opts.testCmd) {
     console.log(`  Running tests: ${opts.testCmd}`);
-    const testPromises = worktrees.map(({ id, path }) =>
-      runTests(id, opts.testCmd!, path)
-    );
+    const testPromises = worktrees.map(({ id, path }) => runTests(id, opts.testCmd!, path));
     testResults = await Promise.all(testPromises);
 
     for (const test of testResults) {
@@ -99,16 +94,10 @@ async function saveResult(result: EnsembleResult): Promise<void> {
 
   // Save full result
   const filename = `run-${result.timestamp.replace(/[:.]/g, "-")}.json`;
-  await writeFile(
-    join(dir, filename),
-    JSON.stringify(result, null, 2)
-  );
+  await writeFile(join(dir, filename), JSON.stringify(result, null, 2));
 
   // Save as latest
-  await writeFile(
-    join(dir, "latest.json"),
-    JSON.stringify(result, null, 2)
-  );
+  await writeFile(join(dir, "latest.json"), JSON.stringify(result, null, 2));
 
   console.log(`  Results saved to ${join(dir, filename)}`);
   console.log();

--- a/src/runners/claude-code.ts
+++ b/src/runners/claude-code.ts
@@ -8,7 +8,7 @@ export async function runClaudeAgent(
   worktreePath: string,
   model: string,
   timeout: number,
-  verbose: boolean
+  verbose: boolean,
 ): Promise<AgentResult> {
   const start = Date.now();
 

--- a/src/scoring/convergence.test.ts
+++ b/src/scoring/convergence.test.ts
@@ -1,7 +1,7 @@
-import { describe, it } from "node:test";
 import assert from "node:assert/strict";
-import { analyzeConvergence, recommend } from "./convergence.js";
+import { describe, it } from "node:test";
 import type { AgentResult } from "../types.js";
+import { analyzeConvergence, recommend } from "./convergence.js";
 
 function makeAgent(overrides: Partial<AgentResult> & { id: number }): AgentResult {
   return {

--- a/src/scoring/convergence.ts
+++ b/src/scoring/convergence.ts
@@ -5,12 +5,8 @@ import type { AgentResult, ConvergenceGroup } from "../types.js";
  * each agent changed. Agents that changed the same set of files are
  * grouped together — a larger group = higher confidence.
  */
-export function analyzeConvergence(
-  agents: AgentResult[]
-): ConvergenceGroup[] {
-  const completed = agents.filter(
-    (a) => a.status === "success" && a.diff.length > 0
-  );
+export function analyzeConvergence(agents: AgentResult[]): ConvergenceGroup[] {
+  const completed = agents.filter((a) => a.status === "success" && a.diff.length > 0);
 
   if (completed.length === 0) return [];
 
@@ -60,7 +56,7 @@ export function analyzeConvergence(
 export function recommend(
   agents: AgentResult[],
   testResults: Array<{ agentId: number; passed: boolean }>,
-  convergence: ConvergenceGroup[]
+  convergence: ConvergenceGroup[],
 ): number | null {
   const completed = agents.filter((a) => a.status === "success" && a.diff.length > 0);
   if (completed.length === 0) return null;

--- a/src/scoring/test-runner.ts
+++ b/src/scoring/test-runner.ts
@@ -7,7 +7,7 @@ const exec = promisify(execFile);
 export async function runTests(
   agentId: number,
   testCmd: string,
-  worktreePath: string
+  worktreePath: string,
 ): Promise<TestResult> {
   const parts = testCmd.split(" ");
   const cmd = parts[0]!;

--- a/src/utils/display.ts
+++ b/src/utils/display.ts
@@ -1,4 +1,4 @@
-import type { AgentResult, TestResult, ConvergenceGroup, EnsembleResult } from "../types.js";
+import type { AgentResult, ConvergenceGroup, EnsembleResult, TestResult } from "../types.js";
 
 const COLORS = {
   reset: "\x1b[0m",
@@ -44,7 +44,7 @@ export function displayResults(result: EnsembleResult): void {
       padRight("Tests", 8) +
       padRight("Files", 8) +
       padRight("+/-", 12) +
-      padRight("Time", 8)
+      padRight("Time", 8),
   );
   console.log("  " + c("dim", "─".repeat(54)));
 
@@ -57,11 +57,7 @@ export function displayResults(result: EnsembleResult): void {
           ? c("yellow", "timeout")
           : c("red", "error");
 
-    const testIcon = test
-      ? test.passed
-        ? c("green", "pass")
-        : c("red", "fail")
-      : c("dim", "n/a");
+    const testIcon = test ? (test.passed ? c("green", "pass") : c("red", "fail")) : c("dim", "n/a");
 
     const isRecommended = result.recommended === agent.id;
     const prefix = isRecommended ? c("cyan", ">>") : "  ";
@@ -73,7 +69,7 @@ export function displayResults(result: EnsembleResult): void {
         padRight(testIcon, 8) +
         padRight(String(agent.filesChanged.length), 8) +
         padRight(`+${agent.linesAdded}/-${agent.linesRemoved}`, 12) +
-        padRight(formatDuration(agent.duration), 8)
+        padRight(formatDuration(agent.duration), 8),
     );
   }
 
@@ -85,9 +81,7 @@ export function displayResults(result: EnsembleResult): void {
     for (const group of result.convergence) {
       const pct = Math.round(group.similarity * 100);
       const bar = "█".repeat(Math.round(pct / 5)) + "░".repeat(20 - Math.round(pct / 5));
-      console.log(
-        `  Agents [${group.agents.join(", ")}]: ${bar} ${pct}%`
-      );
+      console.log(`  Agents [${group.agents.join(", ")}]: ${bar} ${pct}%`);
       console.log(`  ${c("dim", group.description)}`);
       console.log(`  ${c("dim", "Files: " + group.filesChanged.join(", "))}`);
       console.log();
@@ -98,16 +92,14 @@ export function displayResults(result: EnsembleResult): void {
   if (result.recommended !== null) {
     console.log(
       c("cyan", `  Recommended: Agent #${result.recommended}`) +
-        c("dim", " (highest score based on tests + convergence + diff size)")
+        c("dim", " (highest score based on tests + convergence + diff size)"),
     );
     console.log();
   }
 }
 
 export function displayApplyInstructions(result: EnsembleResult): void {
-  const completed = result.agents.filter(
-    (a) => a.status === "success" && a.diff.length > 0
-  );
+  const completed = result.agents.filter((a) => a.status === "success" && a.diff.length > 0);
   if (completed.length === 0) {
     console.log(c("red", "  No agents produced changes."));
     return;
@@ -120,18 +112,15 @@ export function displayApplyInstructions(result: EnsembleResult): void {
   console.log(c("dim", `    cd <worktree-path> && git diff HEAD`));
   console.log();
   console.log("  To apply the recommended agent's changes:");
-  console.log(
-    c("dim", `    cd <repo-root> && git diff --no-index /dev/null <worktree>/...`)
-  );
+  console.log(c("dim", `    cd <repo-root> && git diff --no-index /dev/null <worktree>/...`));
   console.log();
-  console.log(
-    c("dim", "  Worktrees will be cleaned up automatically on next run.")
-  );
+  console.log(c("dim", "  Worktrees will be cleaned up automatically on next run."));
   console.log();
 }
 
 function padRight(str: string, len: number): string {
   // Strip ANSI codes for length calculation
+  // biome-ignore lint/suspicious/noControlCharactersInRegex: intentional ANSI escape sequence matching
   const stripped = str.replace(/\x1b\[[0-9;]*m/g, "");
   const padding = Math.max(0, len - stripped.length);
   return str + " ".repeat(padding);

--- a/src/utils/git.ts
+++ b/src/utils/git.ts
@@ -1,8 +1,8 @@
 import { execFile } from "node:child_process";
-import { promisify } from "node:util";
 import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { promisify } from "node:util";
 
 const exec = promisify(execFile);
 
@@ -56,7 +56,7 @@ export async function getDiff(worktreePath: string): Promise<string> {
 }
 
 export async function getDiffStats(
-  worktreePath: string
+  worktreePath: string,
 ): Promise<{ filesChanged: string[]; linesAdded: number; linesRemoved: number }> {
   try {
     await exec("git", ["add", "-A"], { cwd: worktreePath });
@@ -85,10 +85,7 @@ export async function getDiffStats(
   }
 }
 
-export async function applyDiff(
-  diff: string,
-  targetDir: string
-): Promise<void> {
+export async function applyDiff(diff: string, targetDir: string): Promise<void> {
   const { execFile: execFileCb } = await import("node:child_process");
   const child = execFileCb("git", ["apply", "--3way", "-"], {
     cwd: targetDir,


### PR DESCRIPTION
## Summary
- Biome for TypeScript linting and code formatting
- Lint step added to CI pipeline (runs before build)
- All existing lint/format issues auto-fixed across codebase
- VS Code configuration with Biome as default formatter + format-on-save
- .env.example, CLAUDE.md for contributor onboarding

## Change type
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [x] CI / infrastructure
- [ ] Chore

## Related issue
Closes #8

## How to test
1. `npm run lint` — should pass with 0 errors
2. `npx tsc --noEmit` — type check passes
3. `npm test` — 13 tests pass
4. Open project in VS Code — should recommend Biome extension

## Breaking changes
- [ ] This PR introduces breaking changes

🤖 Generated with [Claude Code](https://claude.ai/code)