### PR TITLE
Add .gitattributes for consistent LF line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,12 @@
+# Enforce LF line endings across all platforms
+* text=auto eol=lf
+
+# Explicitly mark text files
+*.ts text eol=lf
+*.json text eol=lf
+*.md text eol=lf
+*.yml text eol=lf
+*.yaml text eol=lf
+
+# Binary files
+*.png binary


### PR DESCRIPTION
## Summary
- Enforce LF line endings across all platforms via .gitattributes
- Eliminates CRLF/LF warnings during commits on Windows

## Change type
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [x] CI / infrastructure
- [ ] Chore

## Related issue
Closes #14

## How to test
1. Commit a new file on Windows — should not show CRLF warnings
2. `git check-attr eol -- src/cli.ts` — should show `lf`

## Breaking changes
- [ ] This PR introduces breaking changes

🤖 Generated with [Claude Code](https://claude.ai/code)