### PR TITLE
Validate CLI inputs: attempts, timeout, and model

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -24,11 +24,30 @@ program
   .option("--model <model>", "Claude model to use", "sonnet")
   .option("--verbose", "Show detailed output from each agent")
   .action(async (prompt: string, opts) => {
+    const attempts = parseInt(opts.attempts, 10);
+    if (Number.isNaN(attempts) || attempts < 1 || attempts > 20) {
+      console.error("Error: --attempts must be a number between 1 and 20");
+      process.exit(1);
+    }
+
+    const timeout = parseInt(opts.timeout, 10);
+    if (Number.isNaN(timeout) || timeout < 10 || timeout > 600) {
+      console.error("Error: --timeout must be a number between 10 and 600 seconds");
+      process.exit(1);
+    }
+
+    const knownModels = ["sonnet", "opus", "haiku"];
+    if (!knownModels.includes(opts.model) && !opts.model.startsWith("claude-")) {
+      console.warn(
+        `Warning: unknown model "${opts.model}" — known models: ${knownModels.join(", ")}`,
+      );
+    }
+
     await run({
       prompt,
-      attempts: parseInt(opts.attempts, 10),
+      attempts,
       testCmd: opts.testCmd,
-      timeout: parseInt(opts.timeout, 10),
+      timeout,
       model: opts.model,
       verbose: opts.verbose ?? false,
     });


### PR DESCRIPTION
## Summary
- Validate `--attempts` is 1-20, reject NaN values
- Validate `--timeout` is 10-600 seconds, reject NaN values
- Warn (not error) for unknown `--model` values, accept `claude-*` prefixed names

## Change type
- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] CI / infrastructure
- [ ] Chore

## Related issue
Closes #21

## How to test
```bash
thinktank run "test" --attempts 0    # Error: must be 1-20
thinktank run "test" --attempts abc  # Error: must be a number
thinktank run "test" --timeout 5     # Error: must be 10-600
thinktank run "test" --model foo     # Warning: unknown model
```

## Breaking changes
- [x] This PR introduces breaking changes

Commands with `--attempts 0` or `--timeout 0` that previously ran (with undefined behavior) now error immediately.

🤖 Generated with [Claude Code](https://claude.ai/code)