### PR TITLE
Restrict result file permissions and redact agent output

### DIFF
--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -92,12 +92,24 @@ async function saveResult(result: EnsembleResult): Promise<void> {
   const dir = ".thinktank";
   await mkdir(dir, { recursive: true });
 
-  // Save full result
+  // Strip agent stdout/stderr from saved results to avoid credential exposure
+  const sanitizedResult = {
+    ...result,
+    agents: result.agents.map((a) => ({
+      ...a,
+      output: a.output ? "[redacted — use worktree to inspect]" : "",
+      error: a.error ? "[redacted]" : undefined,
+    })),
+  };
+
+  // Save full result with restricted permissions (owner read/write only)
   const filename = `run-${result.timestamp.replace(/[:.]/g, "-")}.json`;
-  await writeFile(join(dir, filename), JSON.stringify(result, null, 2));
+  await writeFile(join(dir, filename), JSON.stringify(sanitizedResult, null, 2), { mode: 0o600 });
 
   // Save as latest
-  await writeFile(join(dir, "latest.json"), JSON.stringify(result, null, 2));
+  await writeFile(join(dir, "latest.json"), JSON.stringify(sanitizedResult, null, 2), {
+    mode: 0o600,
+  });
 
   console.log(`  Results saved to ${join(dir, filename)}`);
   console.log();


### PR DESCRIPTION
## Summary
- Write `.thinktank/` result files with mode 0o600 (owner-only access)
- Redact agent stdout/stderr from saved JSON to prevent credential leakage
- Worktrees remain available for full output inspection

## Change type
- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] CI / infrastructure
- [ ] Chore

## Related issue
Closes #24

## How to test
1. Run `thinktank run "add a comment" -n 2`
2. Check `.thinktank/latest.json` — agent output should say "[redacted]"
3. On Unix: `stat -c %a .thinktank/latest.json` should show `600`

## Breaking changes
- [x] This PR introduces breaking changes

Saved result files no longer contain agent stdout/stderr. Use worktrees to inspect full output.

🤖 Generated with [Claude Code](https://claude.ai/code)