### PR TITLE
Remove unused getCurrentBranch() and applyDiff() exports

### DIFF
--- a/src/utils/git.ts
+++ b/src/utils/git.ts
@@ -11,11 +11,6 @@ export async function getRepoRoot(): Promise<string> {
   return stdout.trim();
 }
 
-export async function getCurrentBranch(): Promise<string> {
-  const { stdout } = await exec("git", ["rev-parse", "--abbrev-ref", "HEAD"]);
-  return stdout.trim();
-}
-
 export async function createWorktree(id: number): Promise<string> {
   const repoRoot = await getRepoRoot();
   const dir = await mkdtemp(join(tmpdir(), `thinktank-agent-${id}-`));
@@ -83,21 +78,6 @@ export async function getDiffStats(
   } catch {
     return { filesChanged: [], linesAdded: 0, linesRemoved: 0 };
   }
-}
-
-export async function applyDiff(diff: string, targetDir: string): Promise<void> {
-  const { execFile: execFileCb } = await import("node:child_process");
-  const child = execFileCb("git", ["apply", "--3way", "-"], {
-    cwd: targetDir,
-  });
-  child.stdin?.write(diff);
-  child.stdin?.end();
-  await new Promise<void>((resolve, reject) => {
-    child.on("close", (code) => {
-      if (code === 0) resolve();
-      else reject(new Error(`git apply failed with code ${code}`));
-    });
-  });
 }
 
 export async function cleanupBranches(): Promise<void> {


### PR DESCRIPTION
## Summary
- Remove `getCurrentBranch()` — exported but never imported
- Remove `applyDiff()` — exported but never imported; had dynamic import anti-pattern

## Change type
- [ ] Bug fix
- [ ] New feature
- [x] Refactor
- [ ] Documentation
- [ ] CI / infrastructure
- [x] Chore

## Related issue
Closes #22

## How to test
```bash
npx tsc --noEmit  # types pass
npm test           # 40 tests pass
npm run lint       # passes
```

## Breaking changes
- [ ] This PR introduces breaking changes

🤖 Generated with [Claude Code](https://claude.ai/code)