### PR TITLE
Fix diff parser for quoted paths and use UUID for branch names

### DIFF
--- a/src/scoring/diff-parser.test.ts
+++ b/src/scoring/diff-parser.test.ts
@@ -54,6 +54,17 @@ diff --git a/b.ts b/b.ts
   it("handles empty diff", () => {
     assert.deepEqual(parseDiff(""), []);
   });
+
+  it("handles filenames with spaces (quoted paths)", () => {
+    const quotedDiff = `diff --git "a/src/my component.tsx" "b/src/my component.tsx"
+--- "a/src/my component.tsx"
++++ "b/src/my component.tsx"
+@@ -1 +1 @@
++export default function MyComponent() {}`;
+    const files = parseDiff(quotedDiff);
+    assert.equal(files.length, 1);
+    assert.equal(files[0]!.path, "src/my component.tsx");
+  });
 });
 
 describe("diffSimilarity", () => {

--- a/src/scoring/diff-parser.ts
+++ b/src/scoring/diff-parser.ts
@@ -19,7 +19,8 @@ export function parseDiff(diff: string): DiffFile[] {
   for (const line of diff.split("\n")) {
     // New file header: diff --git a/path b/path
     if (line.startsWith("diff --git")) {
-      const match = line.match(/diff --git a\/(.+) b\/(.+)/);
+      // Handle both quoted and unquoted paths (spaces in filenames)
+      const match = line.match(/diff --git "?a\/(.+?)"? "?b\/(.+?)"?$/);
       if (match?.[2]) {
         current = { path: match[2], addedLines: [], removedLines: [] };
         files.push(current);

--- a/src/utils/git.ts
+++ b/src/utils/git.ts
@@ -1,4 +1,5 @@
 import { execFile } from "node:child_process";
+import { randomUUID } from "node:crypto";
 import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -14,7 +15,7 @@ export async function getRepoRoot(): Promise<string> {
 export async function createWorktree(id: number): Promise<string> {
   const repoRoot = await getRepoRoot();
   const dir = await mkdtemp(join(tmpdir(), `thinktank-agent-${id}-`));
-  const branchName = `thinktank/agent-${id}-${Date.now()}`;
+  const branchName = `thinktank/agent-${id}-${randomUUID().slice(0, 8)}`;
 
   await exec("git", ["worktree", "add", "-b", branchName, dir], {
     cwd: repoRoot,


### PR DESCRIPTION
## Summary
- Fix diff parser regex to handle filenames with spaces (quoted paths in git diff output)
- Replace `Date.now()` with `crypto.randomUUID()` for worktree branch names to prevent collisions
- New test for quoted path parsing

## Change type
- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] CI / infrastructure
- [ ] Chore

## Related issue
Closes #25
Closes #26

## How to test
```bash
npm test  # 41 tests pass
```

## Breaking changes
- [ ] This PR introduces breaking changes

🤖 Generated with [Claude Code](https://claude.ai/code)