### PR TITLE
Add npm publish workflow and prepublish build step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,47 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+  id-token: write
+
+jobs:
+  release:
+    name: Build & Publish
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Use Node.js 22
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          registry-url: https://registry.npmjs.org/
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Build
+        run: npm run build
+
+      - name: Test
+        run: npm test
+
+      - name: Publish to npm
+        run: npm publish --provenance --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          generate_release_notes: true

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "build": "tsc",
     "dev": "tsx src/cli.ts",
     "test": "tsx --test src/**/*.test.ts",
+    "prepublishOnly": "npm run build && npm test",
     "lint": "biome check src/",
     "lint:fix": "biome check --write src/",
     "format": "biome format --write src/"
@@ -24,6 +25,11 @@
   ],
   "author": "",
   "license": "MIT",
+  "files": [
+    "dist",
+    "README.md",
+    "LICENSE"
+  ],
   "dependencies": {
     "commander": "^14.0.3"
   },


### PR DESCRIPTION
## Summary
- Add `prepublishOnly` script that builds and tests before npm publish
- Add `files` field to package.json limiting published files to dist/, README, LICENSE
- Add release.yml workflow: triggers on `v*` tags, publishes to npm with provenance, creates GitHub Release

## Change type
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [x] CI / infrastructure
- [ ] Chore

## Related issue
Closes #28

## How to test
1. `npm pack --dry-run` — should list only dist/, README.md, LICENSE, package.json
2. Release workflow activates on `git tag v0.1.0 && git push --tags`
3. Requires NPM_TOKEN secret configured in GitHub repo settings

## Breaking changes
- [ ] This PR introduces breaking changes

🤖 Generated with [Claude Code](https://claude.ai/code)