### PR TITLE
Add npm audit and build verification to CI pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,11 +29,18 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Security audit
+        run: npm audit --audit-level=moderate
+        continue-on-error: true
+
       - name: Lint
         run: npm run lint
 
       - name: Build
         run: npm run build
+
+      - name: Verify build output
+        run: test -f dist/cli.js && echo "dist/cli.js exists" || (echo "Build did not produce dist/cli.js" && exit 1)
 
       - name: Check types
         run: npx tsc --noEmit


### PR DESCRIPTION
## Summary
- Add `npm audit` step to CI (continue-on-error until transitive deps are clean)
- Add build output verification: confirms `dist/cli.js` exists after build

## Change type
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [x] CI / infrastructure
- [ ] Chore

## Related issue
Closes #30

## How to test
CI pipeline runs on this PR — verify the new audit and build verification steps appear.

## Breaking changes
- [ ] This PR introduces breaking changes

🤖 Generated with [Claude Code](https://claude.ai/code)