### PR TITLE
Add --preview flag to apply command for reviewing changes

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -57,9 +57,11 @@ program
   .command("apply")
   .description("Apply the recommended (or selected) agent's changes to your repo")
   .option("-a, --agent <number>", "Apply a specific agent's changes instead of the recommended one")
+  .option("-p, --preview", "Show the diff without applying")
   .action(async (opts) => {
     await apply({
       agent: opts.agent ? parseInt(opts.agent, 10) : undefined,
+      preview: opts.preview ?? false,
     });
   });
 

--- a/src/commands/apply.ts
+++ b/src/commands/apply.ts
@@ -2,6 +2,7 @@ import { execFile } from "node:child_process";
 import { readFile } from "node:fs/promises";
 import { join } from "node:path";
 import { promisify } from "node:util";
+import pc from "picocolors";
 import type { EnsembleResult } from "../types.js";
 import { cleanupBranches, getRepoRoot, removeWorktree } from "../utils/git.js";
 
@@ -9,6 +10,7 @@ const exec = promisify(execFile);
 
 export interface ApplyOptions {
   agent?: number;
+  preview?: boolean;
 }
 
 export async function apply(opts: ApplyOptions): Promise<void> {
@@ -39,6 +41,34 @@ export async function apply(opts: ApplyOptions): Promise<void> {
   if (agent.status !== "success" || !agent.diff) {
     console.error(`  Agent #${agentId} has no changes to apply (status: ${agent.status}).`);
     process.exit(1);
+  }
+
+  // Preview mode: show diff and exit
+  if (opts.preview) {
+    console.log();
+    console.log(pc.bold(`  Agent #${agentId} diff:`));
+    console.log(pc.dim("  " + "─".repeat(58)));
+    console.log();
+    for (const line of agent.diff.split("\n")) {
+      if (line.startsWith("+") && !line.startsWith("+++")) {
+        console.log(pc.green(`  ${line}`));
+      } else if (line.startsWith("-") && !line.startsWith("---")) {
+        console.log(pc.red(`  ${line}`));
+      } else if (line.startsWith("@@")) {
+        console.log(pc.cyan(`  ${line}`));
+      } else {
+        console.log(pc.dim(`  ${line}`));
+      }
+    }
+    console.log();
+    console.log(`  Files: ${agent.filesChanged.join(", ")}`);
+    console.log(`  Changes: +${agent.linesAdded}/-${agent.linesRemoved}`);
+    console.log();
+    console.log(
+      pc.dim("  To apply: thinktank apply" + (opts.agent ? ` --agent ${opts.agent}` : "")),
+    );
+    console.log();
+    return;
   }
 
   // Apply the diff


### PR DESCRIPTION
## Summary
- `thinktank apply --preview` shows the diff with syntax-highlighted output
- Green for additions, red for removals, cyan for hunk headers
- Shows file list and change summary without modifying the working tree
- Suggests the apply command after review

## Change type
- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] CI / infrastructure
- [ ] Chore

## Related issue
Closes #33

## How to test
```bash
# After a thinktank run:
thinktank apply --preview           # show recommended agent's diff
thinktank apply --preview --agent 2 # show specific agent's diff
```

## Breaking changes
- [ ] This PR introduces breaking changes

🤖 Generated with [Claude Code](https://claude.ai/code)