### PR TITLE
Fix CI: use shell-safe test commands in test-runner tests

### DIFF
--- a/src/scoring/test-runner.test.ts
+++ b/src/scoring/test-runner.test.ts
@@ -96,13 +96,14 @@ describe("runTests", () => {
   });
 
   it("returns success for passing command", async () => {
-    const result = await runTests(1, "node --eval process.exit(0)", ".");
+    const result = await runTests(1, "node --version", ".");
     assert.equal(result.passed, true);
     assert.equal(result.exitCode, 0);
   });
 
   it("returns failure for failing command", async () => {
-    const result = await runTests(1, "node --eval process.exit(1)", ".");
+    // --require a non-existent module to trigger a guaranteed non-zero exit
+    const result = await runTests(1, "node --require ./nonexistent-module.js", ".");
     assert.equal(result.passed, false);
     assert.ok(result.exitCode !== 0);
   });


### PR DESCRIPTION
## Summary
- Replace `node --eval process.exit(0)` with `node --version` for the passing test
- Replace `node --eval process.exit(1)` with `node --require ./nonexistent-module.js` for the failing test
- Parentheses in the original commands were interpreted by bash on Linux CI, causing the "returns success for passing command" test to fail

## Change type
- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] CI / infrastructure
- [ ] Chore

## Related issue
Fixes CI failure — no dedicated issue.

## How to test
```bash
npm test  # 56 tests pass locally
```
CI should now pass on both Node 22 and 24.

## Breaking changes
- [ ] This PR introduces breaking changes

🤖 Generated with [Claude Code](https://claude.ai/code)