### PR TITLE
Add stats command for ensemble performance data collection

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -5,6 +5,7 @@ import { apply } from "./commands/apply.js";
 import { compare } from "./commands/compare.js";
 import { list } from "./commands/list.js";
 import { run } from "./commands/run.js";
+import { stats } from "./commands/stats.js";
 
 const program = new Command();
 
@@ -83,6 +84,13 @@ program
   .description("List results from the most recent ensemble run")
   .action(async () => {
     await list();
+  });
+
+program
+  .command("stats")
+  .description("Show aggregate statistics across all thinktank runs")
+  .action(async () => {
+    await stats();
   });
 
 program.parse();

--- a/src/commands/stats.ts
+++ b/src/commands/stats.ts
@@ -1,0 +1,56 @@
+import { readdir, readFile } from "node:fs/promises";
+import { join } from "node:path";
+import pc from "picocolors";
+import type { EnsembleResult } from "../types.js";
+
+export async function stats(): Promise<void> {
+  let files: string[];
+  try {
+    const entries = await readdir(".thinktank");
+    files = entries.filter((f) => f.startsWith("run-") && f.endsWith(".json"));
+  } catch {
+    console.log(pc.yellow("  No .thinktank/ directory found. Run `thinktank run` first."));
+    return;
+  }
+
+  if (files.length === 0) {
+    console.log(pc.yellow("  No run files found. Run `thinktank run` first."));
+    return;
+  }
+
+  const results: EnsembleResult[] = [];
+  for (const file of files) {
+    try {
+      const raw = await readFile(join(".thinktank", file), "utf-8");
+      results.push(JSON.parse(raw) as EnsembleResult);
+    } catch {
+      // skip malformed files
+    }
+  }
+
+  const totalRuns = results.length;
+  const avgAgents = results.reduce((sum, r) => sum + r.agents.length, 0) / totalRuns;
+
+  const allScores = results.flatMap((r) => r.convergence.map((g) => g.similarity));
+  const avgConvergence =
+    allScores.length > 0 ? allScores.reduce((sum, s) => sum + s, 0) / allScores.length : 0;
+
+  const testPassRates = results
+    .filter((r) => r.tests.length > 0)
+    .map((r) => r.tests.filter((t) => t.passed).length / r.tests.length);
+  const avgTestPass =
+    testPassRates.length > 0
+      ? testPassRates.reduce((sum, r) => sum + r, 0) / testPassRates.length
+      : null;
+
+  console.log();
+  console.log(pc.bold("  thinktank stats"));
+  console.log(pc.dim("  ─────────────────────────────"));
+  console.log(`  Total runs:          ${pc.cyan(String(totalRuns))}`);
+  console.log(`  Avg agents/run:      ${pc.cyan(avgAgents.toFixed(1))}`);
+  console.log(`  Avg convergence:     ${pc.cyan((avgConvergence * 100).toFixed(1) + "%")}`);
+  if (avgTestPass !== null) {
+    console.log(`  Avg test pass rate:  ${pc.cyan((avgTestPass * 100).toFixed(1) + "%")}`);
+  }
+  console.log();
+}


### PR DESCRIPTION
## Summary
- New `thinktank stats` command aggregates data across all runs
- Displays: total runs, avg agents/run, avg convergence score, avg test pass rate
- Reads all `run-*.json` files from `.thinktank/` directory

**This code was generated by thinktank itself** — 3 agents ran in parallel, Agent #2 was recommended (tests pass, 66% convergence), and applied via `thinktank apply`.

## Change type
- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] CI / infrastructure
- [ ] Chore

## Related issue
Closes #35

## How to test
```bash
# After at least one thinktank run:
thinktank stats
# Output:
#   Total runs:          4
#   Avg agents/run:      2.5
#   Avg convergence:     83.2%
#   Avg test pass rate:  33.3%
```

## Breaking changes
- [ ] This PR introduces breaking changes

🤖 Generated with [thinktank](https://github.com/that-github-user/thinktank) + [Claude Code](https://claude.ai/code)