### PR TITLE
Add graceful Ctrl+C shutdown: clean up worktrees on interrupt

### DIFF
--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -5,7 +5,7 @@ import { analyzeConvergence, recommend } from "../scoring/convergence.js";
 import { runTests } from "../scoring/test-runner.js";
 import type { AgentResult, EnsembleResult, RunOptions } from "../types.js";
 import { displayApplyInstructions, displayHeader, displayResults } from "../utils/display.js";
-import { cleanupBranches, createWorktree } from "../utils/git.js";
+import { cleanupBranches, createWorktree, removeWorktree } from "../utils/git.js";
 
 export async function run(opts: RunOptions): Promise<void> {
   displayHeader(opts.prompt, opts.attempts, opts.model);
@@ -32,6 +32,16 @@ export async function run(opts: RunOptions): Promise<void> {
   // Phase 1: Create worktrees
   console.log("  Creating worktrees...");
   const worktrees: Array<{ id: number; path: string }> = [];
+
+  // Graceful Ctrl+C: clean up all worktrees created so far, then exit.
+  // Registered before worktree creation so any interrupt is handled.
+  const handleSigint = () => {
+    console.log("\n\n  Interrupted — cleaning up worktrees...");
+    Promise.all(worktrees.map(({ path }) => removeWorktree(path).catch(() => {})))
+      .then(() => cleanupBranches().catch(() => {}))
+      .then(() => process.exit(130));
+  };
+  process.on("SIGINT", handleSigint);
 
   for (let i = 1; i <= opts.attempts; i++) {
     const path = await createWorktree(i);
@@ -105,6 +115,9 @@ export async function run(opts: RunOptions): Promise<void> {
 
   // Save result to .thinktank/
   await saveResult(result);
+
+  // Deregister SIGINT handler — run completed normally, no cleanup needed.
+  process.removeListener("SIGINT", handleSigint);
 
   // Note: we intentionally do NOT clean up worktrees here so the user
   // can inspect them. They get cleaned up on next run.


### PR DESCRIPTION
## Summary
- SIGINT handler registered before worktree creation loop
- On Ctrl+C: cleans up all worktrees, prunes branches, exits with code 130
- Handler deregistered after normal run completion
- Prevents worktree leaks on user interrupts

**Generated by thinktank** — 5 agents, Agent #5 recommended (only agent passing tests, +14/-1, single file).

## Change type
- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] CI / infrastructure
- [ ] Chore

## Related issue
Closes #60

## How to test
1. Run `thinktank run "some task" -n 3`
2. Press Ctrl+C mid-run
3. Verify "Interrupted — cleaning up worktrees..." message
4. Verify no leftover worktrees in temp directory

## Breaking changes
- [ ] This PR introduces breaking changes

🤖 Generated with [thinktank](https://github.com/that-github-user/thinktank) + [Claude Code](https://claude.ai/code)