### PR TITLE
Log warnings instead of silently swallowing git errors

### DIFF
--- a/src/utils/git.test.ts
+++ b/src/utils/git.test.ts
@@ -55,3 +55,37 @@ describe("cleanupBranches", () => {
     // Should not throw
   });
 });
+
+describe("getDiff warning on failure", () => {
+  it("warns to stderr and returns empty string for invalid worktree path", async () => {
+    const warnings: string[] = [];
+    const originalWarn = console.warn;
+    console.warn = (...args: unknown[]) => warnings.push(args.join(" "));
+    try {
+      const result = await getDiff("/nonexistent/path/thinktank-test");
+      assert.equal(result, "");
+      assert.equal(warnings.length, 1);
+      assert.ok(warnings[0].includes("getDiff failed"));
+      assert.ok(warnings[0].includes("/nonexistent/path/thinktank-test"));
+    } finally {
+      console.warn = originalWarn;
+    }
+  });
+});
+
+describe("getDiffStats warning on failure", () => {
+  it("warns to stderr and returns empty stats for invalid worktree path", async () => {
+    const warnings: string[] = [];
+    const originalWarn = console.warn;
+    console.warn = (...args: unknown[]) => warnings.push(args.join(" "));
+    try {
+      const result = await getDiffStats("/nonexistent/path/thinktank-test");
+      assert.deepEqual(result, { filesChanged: [], linesAdded: 0, linesRemoved: 0 });
+      assert.equal(warnings.length, 1);
+      assert.ok(warnings[0].includes("getDiffStats failed"));
+      assert.ok(warnings[0].includes("/nonexistent/path/thinktank-test"));
+    } finally {
+      console.warn = originalWarn;
+    }
+  });
+});

--- a/src/utils/git.ts
+++ b/src/utils/git.ts
@@ -46,7 +46,10 @@ export async function getDiff(worktreePath: string): Promise<string> {
       cwd: worktreePath,
     });
     return stdout;
-  } catch {
+  } catch (err) {
+    console.warn(
+      `[thinktank] getDiff failed for worktree ${worktreePath}: ${err instanceof Error ? err.message : String(err)}`,
+    );
     return "";
   }
 }
@@ -76,7 +79,10 @@ export async function getDiffStats(
     }
 
     return { filesChanged, linesAdded, linesRemoved };
-  } catch {
+  } catch (err) {
+    console.warn(
+      `[thinktank] getDiffStats failed for worktree ${worktreePath}: ${err instanceof Error ? err.message : String(err)}`,
+    );
     return { filesChanged: [], linesAdded: 0, linesRemoved: 0 };
   }
 }


### PR DESCRIPTION
## Summary
- getDiff and getDiffStats now log `console.warn` with worktree path and error message on failure
- Previously empty catch blocks silently hid git problems
- Return values unchanged (empty diff/stats) so pipeline continues
- 2 new tests verify warning behavior via console.warn mocking

**Generated by thinktank** — 5 agents, 70% convergence (all changed same 2 files), Agent #4 recommended.

## Change type
- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] CI / infrastructure
- [ ] Chore

## Related issue
Closes #66

## How to test
```bash
npm test  # 66 tests pass
```

## Breaking changes
- [ ] This PR introduces breaking changes

🤖 Generated with [thinktank](https://github.com/that-github-user/thinktank) + [Claude Code](https://claude.ai/code)