### PR TITLE
Handle binary files gracefully in diff parser

### DIFF
--- a/src/scoring/diff-parser.test.ts
+++ b/src/scoring/diff-parser.test.ts
@@ -55,6 +55,20 @@ diff --git a/b.ts b/b.ts
     assert.deepEqual(parseDiff(""), []);
   });
 
+  it("skips binary file entries", () => {
+    const binaryDiff = `diff --git a/image.png b/image.png
+index abc1234..def5678 100644
+Binary files a/image.png and b/image.png differ
+diff --git a/src/auth.ts b/src/auth.ts
+--- a/src/auth.ts
++++ b/src/auth.ts
+@@ -1 +1 @@
++const x = 1;`;
+    const files = parseDiff(binaryDiff);
+    assert.equal(files.length, 1);
+    assert.equal(files[0]!.path, "src/auth.ts");
+  });
+
   it("handles filenames with spaces (quoted paths)", () => {
     const quotedDiff = `diff --git "a/src/my component.tsx" "b/src/my component.tsx"
 --- "a/src/my component.tsx"

--- a/src/scoring/diff-parser.ts
+++ b/src/scoring/diff-parser.ts
@@ -30,6 +30,13 @@ export function parseDiff(diff: string): DiffFile[] {
 
     if (!current) continue;
 
+    // Skip binary file entries — git emits "Binary files a/x and b/x differ"
+    if (line.startsWith("Binary files ") && line.endsWith(" differ")) {
+      current = null;
+      files.pop();
+      continue;
+    }
+
     // Skip metadata lines
     if (line.startsWith("index ") || line.startsWith("---") || line.startsWith("+++")) {
       continue;


### PR DESCRIPTION
## Summary
- Skip "Binary files ... differ" entries in parseDiff
- Previously would attempt to parse binary diff markers as text
- 1 new test verifies binary entries are skipped cleanly

**Generated by thinktank** — 5 agents, 72% convergence, Agent #5 recommended (+21 lines, smallest diff).

## Change type
- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] CI / infrastructure
- [ ] Chore

## Related issue
Closes #68

## How to test
```bash
npm test  # 67 tests pass
```

## Breaking changes
- [ ] This PR introduces breaking changes

🤖 Generated with [thinktank](https://github.com/that-github-user/thinktank) + [Claude Code](https://claude.ai/code)