### PR TITLE
Skip worktree lifecycle tests when inside a git worktree

### DIFF
--- a/src/utils/git.test.ts
+++ b/src/utils/git.test.ts
@@ -1,11 +1,12 @@
 import assert from "node:assert/strict";
-import { after, before, describe, it } from "node:test";
+import { after, describe, it } from "node:test";
 import {
   cleanupBranches,
   createWorktree,
   getDiff,
   getDiffStats,
   getRepoRoot,
+  isInsideWorktree,
   removeWorktree,
 } from "./git.js";
 
@@ -17,28 +18,34 @@ describe("getRepoRoot", () => {
   });
 });
 
-describe("worktree lifecycle", () => {
+describe("worktree lifecycle", async () => {
+  const inWorktree = await isInsideWorktree();
+
   let worktreePath: string;
 
-  it("creates a worktree", async () => {
+  it("creates a worktree", { skip: inWorktree && "cannot nest worktrees" }, async () => {
     worktreePath = await createWorktree(99);
     assert.ok(worktreePath.length > 0);
     assert.ok(worktreePath.includes("thinktank-agent-99"));
   });
 
-  it("gets empty diff for unchanged worktree", async () => {
+  it("gets empty diff for unchanged worktree", {
+    skip: inWorktree && "cannot nest worktrees",
+  }, async () => {
     const diff = await getDiff(worktreePath);
     assert.equal(diff, "");
   });
 
-  it("gets empty diff stats for unchanged worktree", async () => {
+  it("gets empty diff stats for unchanged worktree", {
+    skip: inWorktree && "cannot nest worktrees",
+  }, async () => {
     const stats = await getDiffStats(worktreePath);
     assert.deepEqual(stats.filesChanged, []);
     assert.equal(stats.linesAdded, 0);
     assert.equal(stats.linesRemoved, 0);
   });
 
-  it("removes the worktree", async () => {
+  it("removes the worktree", { skip: inWorktree && "cannot nest worktrees" }, async () => {
     await removeWorktree(worktreePath);
     // Should not throw
   });

--- a/src/utils/git.ts
+++ b/src/utils/git.ts
@@ -12,6 +12,12 @@ export async function getRepoRoot(): Promise<string> {
   return stdout.trim();
 }
 
+export async function isInsideWorktree(): Promise<boolean> {
+  const { stdout: gitDir } = await exec("git", ["rev-parse", "--git-dir"]);
+  const { stdout: commonDir } = await exec("git", ["rev-parse", "--git-common-dir"]);
+  return gitDir.trim() !== commonDir.trim();
+}
+
 export async function createWorktree(id: number): Promise<string> {
   const repoRoot = await getRepoRoot();
   const dir = await mkdtemp(join(tmpdir(), `thinktank-agent-${id}-`));


### PR DESCRIPTION
## Summary
- Adds `isInsideWorktree()` helper that detects worktree environments by comparing `--git-dir` vs `--git-common-dir`
- Skips the 4 worktree lifecycle tests with `"cannot nest worktrees"` when already running inside a worktree
- Tests still run normally in non-worktree environments (CI, local dev)

Fixes #86

## Test plan
- [x] `npm run build` passes
- [x] `npm test` passes (67 tests: 63 pass, 4 skipped)
- [x] `biome check` passes on changed files
- [ ] Verify tests run (not skip) when executed from the main repo checkout

🤖 Generated with [Claude Code](https://claude.com/claude-code)