### PR TITLE
Fix nested worktree issue and enable dogfooding with passing tests

### DIFF
--- a/src/utils/git.test.ts
+++ b/src/utils/git.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { after, before, describe, it } from "node:test";
+import { after, describe, it } from "node:test";
 import {
   cleanupBranches,
   createWorktree,

--- a/src/utils/git.ts
+++ b/src/utils/git.ts
@@ -2,7 +2,7 @@ import { execFile } from "node:child_process";
 import { randomUUID } from "node:crypto";
 import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 import { promisify } from "node:util";
 
 const exec = promisify(execFile);
@@ -12,8 +12,18 @@ export async function getRepoRoot(): Promise<string> {
   return stdout.trim();
 }
 
+/**
+ * Returns the root of the main repository, even when called from inside a worktree.
+ * This is necessary because git does not support nested worktrees.
+ */
+async function getMainRepoRoot(): Promise<string> {
+  const { stdout } = await exec("git", ["rev-parse", "--path-format=absolute", "--git-common-dir"]);
+  // --git-common-dir returns /path/to/main-repo/.git for both worktrees and the main repo
+  return dirname(stdout.trim());
+}
+
 export async function createWorktree(id: number): Promise<string> {
-  const repoRoot = await getRepoRoot();
+  const repoRoot = await getMainRepoRoot();
   const dir = await mkdtemp(join(tmpdir(), `thinktank-agent-${id}-`));
   const branchName = `thinktank/agent-${id}-${randomUUID().slice(0, 8)}`;
 
@@ -21,11 +31,38 @@ export async function createWorktree(id: number): Promise<string> {
     cwd: repoRoot,
   });
 
+  // Symlink node_modules from the main repo so tests and tools work in worktrees.
+  // Git worktrees don't include gitignored directories like node_modules.
+  const mainNodeModules = join(repoRoot, "node_modules");
+  const worktreeNodeModules = join(dir, "node_modules");
+  try {
+    const { lstat, symlink } = await import("node:fs/promises");
+    await lstat(mainNodeModules);
+    await symlink(mainNodeModules, worktreeNodeModules, "junction");
+  } catch {
+    // No node_modules in main repo or symlink failed — not critical
+  }
+
   return dir;
 }
 
 export async function removeWorktree(worktreePath: string): Promise<void> {
-  const repoRoot = await getRepoRoot();
+  const repoRoot = await getMainRepoRoot();
+
+  // Remove node_modules symlink/junction BEFORE removing worktree.
+  // On Windows, rm -rf follows junctions and deletes the target.
+  try {
+    const nmPath = join(worktreePath, "node_modules");
+    const { lstat, unlink } = await import("node:fs/promises");
+    const stat = await lstat(nmPath);
+    if (stat.isSymbolicLink() || stat.isDirectory()) {
+      // unlink removes the junction/symlink without following it
+      await unlink(nmPath).catch(() => {});
+    }
+  } catch {
+    // No symlink to remove
+  }
+
   try {
     await exec("git", ["worktree", "remove", worktreePath, "--force"], {
       cwd: repoRoot,
@@ -88,7 +125,7 @@ export async function getDiffStats(
 }
 
 export async function cleanupBranches(): Promise<void> {
-  const repoRoot = await getRepoRoot();
+  const repoRoot = await getMainRepoRoot();
   const { stdout } = await exec("git", ["branch", "--list", "thinktank/*"], {
     cwd: repoRoot,
   });


### PR DESCRIPTION
## Summary
Three fixes that together solve test failures during dogfooding:

1. **getMainRepoRoot()** — uses `git rev-parse --git-common-dir` to find the main repo root even from inside a worktree. Fixes createWorktree/removeWorktree/cleanupBranches.

2. **node_modules symlink** — creates a junction from worktree to main repo's node_modules so `npm test`, `tsx`, and all dev tools work inside worktrees.

3. **Safe junction removal** — unlinks the node_modules junction BEFORE removing the worktree to prevent `rm -rf` from following the junction and deleting the main repo's node_modules (critical on Windows).

**Generated by thinktank with Opus** — Agent #5 found the root cause fix (getMainRepoRoot) instead of the workaround (skip tests). The node_modules symlink and safe removal were added manually after discovering the additional issues during testing.

## Verified dogfooding
After this fix, `thinktank run ... -t "npm test"` on the thinktank repo itself shows:
- Both agents: tests PASS (previously: all agents failed)
- node_modules intact after worktree cleanup (previously: deleted via junction)

## Change type
- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] CI / infrastructure
- [ ] Chore

## Related issue
Closes #86

## How to test
```bash
npm test  # 67 tests pass
npx tsx src/cli.ts run --attempts 2 -t "npm test" "trivial task"
# Both agents should show tests: pass
ls node_modules/commander  # Should still exist after run
```

## Breaking changes
- [ ] This PR introduces breaking changes

🤖 Generated with [thinktank](https://github.com/that-github-user/thinktank) (Opus) + manual fixes + [Claude Code](https://claude.ai/code)