### PR TITLE
Add pre-flight validation before spawning agents

### DIFF
--- a/src/commands/run.test.ts
+++ b/src/commands/run.test.ts
@@ -1,6 +1,61 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
-import { makeResultFilename } from "./run.js";
+import type { RunOptions } from "../types.js";
+import { makeResultFilename, preflightValidation } from "./run.js";
+
+function makeOpts(overrides: Partial<RunOptions> = {}): RunOptions {
+  return {
+    prompt: "fix the bug",
+    attempts: 3,
+    timeout: 300,
+    model: "sonnet",
+    verbose: false,
+    ...overrides,
+  };
+}
+
+describe("preflightValidation", () => {
+  it("passes in a valid git repo with no test command", async () => {
+    const result = await preflightValidation(makeOpts());
+    assert.equal(result, null);
+  });
+
+  it("passes with a valid test command", async () => {
+    const result = await preflightValidation(makeOpts({ testCmd: "npm test" }));
+    assert.equal(result, null);
+  });
+
+  it("rejects test command with shell operators", async () => {
+    const result = await preflightValidation(makeOpts({ testCmd: "npm test && echo done" }));
+    assert.ok(result);
+    assert.ok(result.includes("Invalid --test-cmd"));
+    assert.ok(result.includes("shell operators"));
+  });
+
+  it("rejects test command with pipes", async () => {
+    const result = await preflightValidation(makeOpts({ testCmd: "npm test | tee out.log" }));
+    assert.ok(result);
+    assert.ok(result.includes("Invalid --test-cmd"));
+  });
+
+  it("rejects empty test command", async () => {
+    const result = await preflightValidation(makeOpts({ testCmd: "  " }));
+    assert.ok(result);
+    assert.ok(result.includes("Invalid --test-cmd"));
+  });
+
+  it("rejects test command with backticks", async () => {
+    const result = await preflightValidation(makeOpts({ testCmd: "`rm -rf /`" }));
+    assert.ok(result);
+    assert.ok(result.includes("Invalid --test-cmd"));
+  });
+
+  it("rejects test command with redirection", async () => {
+    const result = await preflightValidation(makeOpts({ testCmd: "npm test > out.log" }));
+    assert.ok(result);
+    assert.ok(result.includes("Invalid --test-cmd"));
+  });
+});
 
 describe("makeResultFilename", () => {
   it("produces no colons in filename", () => {

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -2,10 +2,33 @@ import { mkdir, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { getDefaultRunner, getRunner } from "../runners/registry.js";
 import { analyzeConvergence, recommend } from "../scoring/convergence.js";
-import { runTests } from "../scoring/test-runner.js";
+import { runTests, validateTestCommand } from "../scoring/test-runner.js";
 import type { AgentResult, EnsembleResult, RunOptions } from "../types.js";
 import { displayApplyInstructions, displayHeader, displayResults } from "../utils/display.js";
-import { cleanupBranches, createWorktree, removeWorktree } from "../utils/git.js";
+import { cleanupBranches, createWorktree, getRepoRoot, removeWorktree } from "../utils/git.js";
+
+/**
+ * Pre-flight validation before spawning agents.
+ * Returns an error message if validation fails, or null if everything is OK.
+ */
+export async function preflightValidation(opts: RunOptions): Promise<string | null> {
+  // Check: current directory is a git repo with an accessible working tree
+  try {
+    await getRepoRoot();
+  } catch {
+    return "Not a git repository. Run this command from inside a git repo.";
+  }
+
+  // Check: test command is valid (if specified)
+  if (opts.testCmd) {
+    const testError = validateTestCommand(opts.testCmd);
+    if (testError) {
+      return `Invalid --test-cmd: ${testError}`;
+    }
+  }
+
+  return null;
+}
 
 export async function run(opts: RunOptions): Promise<void> {
   displayHeader(opts.prompt, opts.attempts, opts.model);
@@ -23,6 +46,13 @@ export async function run(opts: RunOptions): Promise<void> {
     console.error(
       `  Runner "${runner.name}" is not available. Is ${runner.description} installed?`,
     );
+    process.exit(1);
+  }
+
+  // Pre-flight validation
+  const preflightError = await preflightValidation(opts);
+  if (preflightError) {
+    console.error(`  ${preflightError}`);
     process.exit(1);
   }
 


### PR DESCRIPTION
## Summary
- `preflightValidation()` checks git repo + test command safety before worktree creation
- Fails fast with actionable error messages instead of cryptic failures mid-run
- 7 new tests: git repo check, valid test cmd, shell operator rejection, empty cmd

**Generated by thinktank Opus** — 5 agents, all pass, Agent #5 recommended (+88/-3).

## Change type
- [x] New feature
- [ ] Bug fix

## Related issue
Closes #54

## How to test
```bash
npm test  # 79 tests pass
cd /tmp && thinktank run "task"  # "Not a git repository" error
```

## Breaking changes
- [ ] This PR introduces breaking changes

🤖 Generated with [thinktank](https://github.com/that-github-user/thinktank) (Opus)