### PR TITLE
Add --test-timeout flag and fix CI node_modules symlink in diff

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -24,6 +24,7 @@ program
   .option("-n, --attempts <number>", "Number of parallel attempts", "3")
   .option("-f, --file <path>", "Read prompt from a file (avoids shell expansion issues)")
   .option("-t, --test-cmd <command>", "Test command to verify results (e.g., 'npm test')")
+  .option("--test-timeout <seconds>", "Timeout for test command in seconds", "120")
   .option("--timeout <seconds>", "Timeout per agent in seconds", "300")
   .option("--model <model>", "Claude model to use", "sonnet")
   .option("-r, --runner <name>", "AI coding tool to use (default: claude-code)")
@@ -34,6 +35,12 @@ program
     const attempts = parseInt(opts.attempts, 10);
     if (Number.isNaN(attempts) || attempts < 1 || attempts > 20) {
       console.error("Error: --attempts must be a number between 1 and 20");
+      process.exit(1);
+    }
+
+    const testTimeout = parseInt(opts.testTimeout, 10);
+    if (Number.isNaN(testTimeout) || testTimeout < 10 || testTimeout > 600) {
+      console.error("Error: --test-timeout must be a number between 10 and 600 seconds");
       process.exit(1);
     }
 
@@ -54,6 +61,7 @@ program
       prompt,
       attempts,
       testCmd: opts.testCmd,
+      testTimeout,
       timeout,
       model: opts.model,
       runner: opts.runner,

--- a/src/commands/run.test.ts
+++ b/src/commands/run.test.ts
@@ -7,6 +7,7 @@ function makeOpts(overrides: Partial<RunOptions> = {}): RunOptions {
   return {
     prompt: "fix the bug",
     attempts: 3,
+    testTimeout: 120,
     timeout: 300,
     model: "sonnet",
     verbose: false,

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -112,7 +112,10 @@ export async function run(opts: RunOptions): Promise<void> {
 
   if (opts.testCmd) {
     console.log(`  Running tests: ${opts.testCmd}`);
-    const testPromises = worktrees.map(({ id, path }) => runTests(id, opts.testCmd!, path));
+    const testTimeoutMs = opts.testTimeout * 1000;
+    const testPromises = worktrees.map(({ id, path }) =>
+      runTests(id, opts.testCmd!, path, testTimeoutMs),
+    );
     testResults = await Promise.all(testPromises);
 
     for (const test of testResults) {

--- a/src/scoring/test-runner.test.ts
+++ b/src/scoring/test-runner.test.ts
@@ -107,4 +107,12 @@ describe("runTests", () => {
     assert.equal(result.passed, false);
     assert.ok(result.exitCode !== 0);
   });
+
+  it("respects custom timeout parameter", async () => {
+    // Use a very short timeout (100ms) with a command that sleeps longer
+    const result = await runTests(1, "node -e process.stdin.resume()", ".", 100);
+    assert.equal(result.passed, false);
+    assert.equal(result.exitCode, 124);
+    assert.ok(result.output.includes("timed out after 0.1s"));
+  });
 });

--- a/src/scoring/test-runner.ts
+++ b/src/scoring/test-runner.ts
@@ -6,7 +6,7 @@ import type { TestResult } from "../types.js";
 
 const exec = promisify(execFile);
 
-const TEST_TIMEOUT_MS = 120_000;
+const DEFAULT_TEST_TIMEOUT_MS = 120_000;
 
 /** Shell operators that indicate command chaining — reject these. */
 const SHELL_OPERATORS = /[;|&`><]/;
@@ -52,6 +52,7 @@ export async function runTests(
   agentId: number,
   testCmd: string,
   worktreePath: string,
+  timeoutMs: number = DEFAULT_TEST_TIMEOUT_MS,
 ): Promise<TestResult> {
   // Security: validate command before execution
   const validationError = validateTestCommand(testCmd);
@@ -91,7 +92,7 @@ export async function runTests(
     // while keeping args as an array to prevent injection via arguments.
     const { stdout, stderr } = await exec(cmd, args, {
       cwd: worktreePath,
-      timeout: TEST_TIMEOUT_MS,
+      timeout: timeoutMs,
       shell: true,
       env: { ...process.env, CI: "true" },
     });
@@ -114,7 +115,7 @@ export async function runTests(
       return {
         agentId,
         passed: false,
-        output: `Test command timed out after ${TEST_TIMEOUT_MS / 1000}s`,
+        output: `Test command timed out after ${timeoutMs / 1000}s`,
         exitCode: 124,
       };
     }

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,6 +2,7 @@ export interface RunOptions {
   prompt: string;
   attempts: number;
   testCmd?: string;
+  testTimeout: number;
   timeout: number;
   model: string;
   verbose: boolean;

--- a/src/utils/git.ts
+++ b/src/utils/git.ts
@@ -77,8 +77,8 @@ export async function removeWorktree(worktreePath: string): Promise<void> {
 export async function getDiff(worktreePath: string): Promise<string> {
   try {
     // Include both staged and unstaged changes relative to HEAD
-    // First add all changes so they show in the diff
-    await exec("git", ["add", "-A"], { cwd: worktreePath });
+    // Exclude node_modules symlink (created by createWorktree for tool access)
+    await exec("git", ["add", "-A", "--", ".", ":!node_modules"], { cwd: worktreePath });
     const { stdout } = await exec("git", ["diff", "--cached", "HEAD"], {
       cwd: worktreePath,
     });
@@ -95,7 +95,7 @@ export async function getDiffStats(
   worktreePath: string,
 ): Promise<{ filesChanged: string[]; linesAdded: number; linesRemoved: number }> {
   try {
-    await exec("git", ["add", "-A"], { cwd: worktreePath });
+    await exec("git", ["add", "-A", "--", ".", ":!node_modules"], { cwd: worktreePath });
     const { stdout } = await exec("git", ["diff", "--cached", "--stat", "HEAD"], {
       cwd: worktreePath,
     });


### PR DESCRIPTION
## Summary
- `--test-timeout <seconds>` flag (default 120) for configurable test timeouts
- Fix CI failure: exclude node_modules symlink from `git add` in getDiff/getDiffStats
- 1 new test for timeout configuration

**Generated by thinktank Opus** — 5 agents, all pass, 71% convergence, Agent #2 recommended.

## Change type
- [x] Bug fix
- [x] New feature

## Related issue
Closes #58

## How to test
```bash
npm test  # 80 tests pass
thinktank run --help  # shows --test-timeout flag
```

## Breaking changes
- [ ] This PR introduces breaking changes

🤖 Generated with [thinktank](https://github.com/that-github-user/thinktank) (Opus)