### PR TITLE
Fix git add regression: use git reset instead of pathspec exclusion

### DIFF
--- a/src/utils/git.ts
+++ b/src/utils/git.ts
@@ -78,7 +78,9 @@ export async function getDiff(worktreePath: string): Promise<string> {
   try {
     // Include both staged and unstaged changes relative to HEAD
     // Exclude node_modules symlink (created by createWorktree for tool access)
-    await exec("git", ["add", "-A", "--", ".", ":!node_modules"], { cwd: worktreePath });
+    await exec("git", ["add", "-A"], { cwd: worktreePath });
+    // Unstage node_modules symlink if it got picked up (created by createWorktree)
+    await exec("git", ["reset", "HEAD", "--", "node_modules"], { cwd: worktreePath }).catch(() => {});
     const { stdout } = await exec("git", ["diff", "--cached", "HEAD"], {
       cwd: worktreePath,
     });
@@ -95,7 +97,9 @@ export async function getDiffStats(
   worktreePath: string,
 ): Promise<{ filesChanged: string[]; linesAdded: number; linesRemoved: number }> {
   try {
-    await exec("git", ["add", "-A", "--", ".", ":!node_modules"], { cwd: worktreePath });
+    await exec("git", ["add", "-A"], { cwd: worktreePath });
+    // Unstage node_modules symlink if it got picked up (created by createWorktree)
+    await exec("git", ["reset", "HEAD", "--", "node_modules"], { cwd: worktreePath }).catch(() => {});
     const { stdout } = await exec("git", ["diff", "--cached", "--stat", "HEAD"], {
       cwd: worktreePath,
     });


### PR DESCRIPTION
## Summary
The `:!node_modules` pathspec in `git add` causes errors on repos that gitignore node_modules (which is most repos). Replace with `git add -A` followed by `git reset HEAD -- node_modules` to unstage the symlink.

## Change type
- [x] Bug fix

## How to test
```bash
npm test  # 80 tests pass
npx tsx src/cli.ts run --attempts 2 -t "npm test" "trivial task"
# Should show files changed, not 0
```

## Breaking changes
- [ ] This PR introduces breaking changes

🤖 Generated with [Claude Code](https://claude.ai/code)