### PR TITLE
Fix CI: cross-platform timeout test and Biome formatting

### DIFF
--- a/src/scoring/test-runner.test.ts
+++ b/src/scoring/test-runner.test.ts
@@ -110,7 +110,7 @@ describe("runTests", () => {
 
   it("respects custom timeout parameter", async () => {
     // Use a very short timeout (100ms) with a command that sleeps longer
-    const result = await runTests(1, "node -e process.stdin.resume()", ".", 100);
+    const result = await runTests(1, "node --interactive", ".", 100);
     assert.equal(result.passed, false);
     assert.equal(result.exitCode, 124);
     assert.ok(result.output.includes("timed out after 0.1s"));

--- a/src/utils/git.ts
+++ b/src/utils/git.ts
@@ -80,7 +80,9 @@ export async function getDiff(worktreePath: string): Promise<string> {
     // Exclude node_modules symlink (created by createWorktree for tool access)
     await exec("git", ["add", "-A"], { cwd: worktreePath });
     // Unstage node_modules symlink if it got picked up (created by createWorktree)
-    await exec("git", ["reset", "HEAD", "--", "node_modules"], { cwd: worktreePath }).catch(() => {});
+    await exec("git", ["reset", "HEAD", "--", "node_modules"], { cwd: worktreePath }).catch(
+      () => {},
+    );
     const { stdout } = await exec("git", ["diff", "--cached", "HEAD"], {
       cwd: worktreePath,
     });
@@ -99,7 +101,9 @@ export async function getDiffStats(
   try {
     await exec("git", ["add", "-A"], { cwd: worktreePath });
     // Unstage node_modules symlink if it got picked up (created by createWorktree)
-    await exec("git", ["reset", "HEAD", "--", "node_modules"], { cwd: worktreePath }).catch(() => {});
+    await exec("git", ["reset", "HEAD", "--", "node_modules"], { cwd: worktreePath }).catch(
+      () => {},
+    );
     const { stdout } = await exec("git", ["diff", "--cached", "--stat", "HEAD"], {
       cwd: worktreePath,
     });


### PR DESCRIPTION
## Summary
- Replace `node -e process.stdin.resume()` with `node --interactive` for timeout test (no parens = no bash issues)
- Wrap long `.catch()` lines per Biome formatter

**Generated by thinktank Opus** — 5 agents, all pass. Two clusters: Agents 1&5 (70%) vs 2,3,4 (57%). All agreed on `node --interactive`. Agent #1 recommended (+7/-3).

## Change type
- [x] Bug fix

## Related issue
Fixes CI failure from #92/#93.

## Breaking changes
- [ ] This PR introduces breaking changes

🤖 Generated with [thinktank](https://github.com/that-github-user/thinktank) (Opus)