### PR TITLE
Show scoring breakdown in recommendation output

### DIFF
--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -129,7 +129,7 @@ export async function run(opts: RunOptions): Promise<void> {
   const convergence = analyzeConvergence(agents);
 
   // Phase 5: Recommendation
-  const recommended = recommend(agents, testResults, convergence);
+  const { recommended, scores } = recommend(agents, testResults, convergence);
 
   // Build result object
   const result: EnsembleResult = {
@@ -140,6 +140,7 @@ export async function run(opts: RunOptions): Promise<void> {
     tests: testResults,
     convergence,
     recommended,
+    scores,
   };
 
   // Display results

--- a/src/scoring/convergence.test.ts
+++ b/src/scoring/convergence.test.ts
@@ -93,7 +93,9 @@ describe("analyzeConvergence", () => {
 describe("recommend", () => {
   it("returns null for no completed agents", () => {
     const agents = [makeAgent({ id: 1, status: "error", diff: "" })];
-    assert.equal(recommend(agents, [], []), null);
+    const result = recommend(agents, [], []);
+    assert.equal(result.recommended, null);
+    assert.deepEqual(result.scores, []);
   });
 
   it("prefers agents that pass tests", () => {
@@ -106,8 +108,9 @@ describe("recommend", () => {
       { agentId: 2, passed: false },
     ];
     const convergence = analyzeConvergence(agents);
+    const result = recommend(agents, tests, convergence);
 
-    assert.equal(recommend(agents, tests, convergence), 1);
+    assert.equal(result.recommended, 1);
   });
 
   it("prefers agents in larger convergence group when tests are equal", () => {
@@ -128,10 +131,10 @@ describe("recommend", () => {
       { agentId: 3, passed: true },
     ];
     const convergence = analyzeConvergence(agents);
-    const rec = recommend(agents, tests, convergence);
+    const result = recommend(agents, tests, convergence);
 
     // Should pick agent 1 or 2 (in the majority group), not 3
-    assert.ok(rec === 1 || rec === 2);
+    assert.ok(result.recommended === 1 || result.recommended === 2);
   });
 
   it("prefers smaller diffs as tiebreaker", () => {
@@ -140,7 +143,58 @@ describe("recommend", () => {
       makeAgent({ id: 2, diff: DIFF_A, linesAdded: 5, linesRemoved: 2 }),
     ];
     const convergence = analyzeConvergence(agents);
+    const result = recommend(agents, [], convergence);
 
-    assert.equal(recommend(agents, [], convergence), 2);
+    assert.equal(result.recommended, 2);
+  });
+
+  it("returns per-agent score breakdowns", () => {
+    const agents = [
+      makeAgent({ id: 1, diff: DIFF_A, linesAdded: 20, linesRemoved: 10 }),
+      makeAgent({ id: 2, diff: DIFF_B, linesAdded: 5, linesRemoved: 2, filesChanged: ["b.ts"] }),
+    ];
+    const tests = [
+      { agentId: 1, passed: true },
+      { agentId: 2, passed: false },
+    ];
+    const convergence = analyzeConvergence(agents);
+    const result = recommend(agents, tests, convergence);
+
+    assert.equal(result.scores.length, 2);
+
+    const score1 = result.scores.find((s) => s.agentId === 1);
+    const score2 = result.scores.find((s) => s.agentId === 2);
+    assert.ok(score1);
+    assert.ok(score2);
+
+    assert.equal(score1.testPoints, 100);
+    assert.equal(score2.testPoints, 0);
+
+    assert.ok(score1.convergencePoints >= 0);
+    assert.ok(score1.diffSizePoints >= 0);
+    assert.equal(
+      score1.total,
+      score1.testPoints + score1.convergencePoints + score1.diffSizePoints,
+    );
+    assert.equal(
+      score2.total,
+      score2.testPoints + score2.convergencePoints + score2.diffSizePoints,
+    );
+  });
+
+  it("gives higher diffSizePoints to smaller diffs", () => {
+    const agents = [
+      makeAgent({ id: 1, diff: DIFF_A, linesAdded: 50, linesRemoved: 20 }),
+      makeAgent({ id: 2, diff: DIFF_A, linesAdded: 5, linesRemoved: 2 }),
+    ];
+    const convergence = analyzeConvergence(agents);
+    const result = recommend(agents, [], convergence);
+
+    const score1 = result.scores.find((s) => s.agentId === 1);
+    const score2 = result.scores.find((s) => s.agentId === 2);
+    assert.ok(score1);
+    assert.ok(score2);
+
+    assert.ok(score2.diffSizePoints > score1.diffSizePoints);
   });
 });

--- a/src/scoring/convergence.ts
+++ b/src/scoring/convergence.ts
@@ -1,4 +1,4 @@
-import type { AgentResult, ConvergenceGroup } from "../types.js";
+import type { AgentResult, AgentScore, ConvergenceGroup } from "../types.js";
 import { pairwiseSimilarity } from "./diff-parser.js";
 
 /**
@@ -127,39 +127,45 @@ export function recommend(
   agents: AgentResult[],
   testResults: Array<{ agentId: number; passed: boolean }>,
   convergence: ConvergenceGroup[],
-): number | null {
+): { recommended: number | null; scores: AgentScore[] } {
   const completed = agents.filter((a) => a.status === "success" && a.diff.length > 0);
-  if (completed.length === 0) return null;
+  if (completed.length === 0) return { recommended: null, scores: [] };
 
-  const scores = new Map<number, number>();
+  const agentScores: AgentScore[] = [];
 
   for (const agent of completed) {
-    let score = 0;
-
     // Tests passing is the strongest signal
     const test = testResults.find((t) => t.agentId === agent.id);
-    if (test?.passed) score += 100;
+    const testPoints = test?.passed ? 100 : 0;
 
     // Being in the largest convergence group
     const group = convergence.find((g) => g.agents.includes(agent.id));
-    if (group) score += group.similarity * 50;
+    const convergencePoints = group ? group.similarity * 50 : 0;
 
     // Smaller diffs preferred (normalized)
     const maxLines = Math.max(...completed.map((a) => a.linesAdded + a.linesRemoved), 1);
     const agentLines = agent.linesAdded + agent.linesRemoved;
-    score += (1 - agentLines / maxLines) * 10;
+    const diffSizePoints = (1 - agentLines / maxLines) * 10;
 
-    scores.set(agent.id, score);
+    const total = testPoints + convergencePoints + diffSizePoints;
+
+    agentScores.push({
+      agentId: agent.id,
+      testPoints,
+      convergencePoints: Math.round(convergencePoints * 100) / 100,
+      diffSizePoints: Math.round(diffSizePoints * 100) / 100,
+      total: Math.round(total * 100) / 100,
+    });
   }
 
   let bestId: number | null = null;
   let bestScore = -1;
-  for (const [id, score] of scores) {
-    if (score > bestScore) {
-      bestScore = score;
-      bestId = id;
+  for (const score of agentScores) {
+    if (score.total > bestScore) {
+      bestScore = score.total;
+      bestId = score.agentId;
     }
   }
 
-  return bestId;
+  return { recommended: bestId, scores: agentScores };
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -37,6 +37,14 @@ export interface ConvergenceGroup {
   description: string;
 }
 
+export interface AgentScore {
+  agentId: number;
+  testPoints: number;
+  convergencePoints: number;
+  diffSizePoints: number;
+  total: number;
+}
+
 export interface EnsembleResult {
   prompt: string;
   model: string;
@@ -45,4 +53,5 @@ export interface EnsembleResult {
   tests: TestResult[];
   convergence: ConvergenceGroup[];
   recommended: number | null;
+  scores: AgentScore[];
 }

--- a/src/utils/display.ts
+++ b/src/utils/display.ts
@@ -69,6 +69,35 @@ export function displayResults(result: EnsembleResult): void {
     }
   }
 
+  // Scoring breakdown
+  if (result.scores.length > 0) {
+    console.log(pc.bold("Scoring"));
+    console.log(pc.dim("─".repeat(60)));
+    console.log(
+      "  " +
+        padRight("Agent", 8) +
+        padRight("Tests", 10) +
+        padRight("Converge", 10) +
+        padRight("Diff", 10) +
+        padRight("Total", 10),
+    );
+    console.log("  " + pc.dim("─".repeat(48)));
+
+    for (const score of result.scores) {
+      const isRecommended = result.recommended === score.agentId;
+      const prefix = isRecommended ? pc.cyan(">>") : "  ";
+      console.log(
+        prefix +
+          padRight(`#${score.agentId}`, 8) +
+          padRight(String(score.testPoints), 10) +
+          padRight(String(score.convergencePoints), 10) +
+          padRight(String(score.diffSizePoints), 10) +
+          padRight(String(score.total), 10),
+      );
+    }
+    console.log();
+  }
+
   // Recommendation
   if (result.recommended !== null) {
     console.log(


### PR DESCRIPTION
## Summary
- `recommend()` returns per-agent score breakdowns: testPoints, convergencePoints, diffSizePoints, total
- Display shows scoring table after recommendation so users can understand and trust the pick
- Updated EnsembleResult type with scores field
- 2 new tests for score breakdown

**Generated by thinktank Opus** — 5 agents, **81% convergence (strong consensus)**, all pass, all changed same 5 files. Agent #1 recommended (+120/-21).

## Change type
- [x] New feature

## Related issue
Closes #62

## How to test
```bash
npm test  # 82 tests pass
npx tsx src/cli.ts run "trivial task" -n 2
# Output should show Scoring section with per-agent breakdown
```

## Breaking changes
- [x] This PR introduces breaking changes

`recommend()` return type changed from `number | null` to `{ recommended: number | null; scores: ScoreBreakdown[] }`. Internal only — no external consumers.

🤖 Generated with [thinktank](https://github.com/that-github-user/thinktank) (Opus)