### PR TITLE
Switch default scoring from weighted to copeland

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -43,7 +43,7 @@ program
     "Convergence clustering similarity threshold (0.0-1.0)",
     String(cfg.threshold),
   )
-  .option("--scoring <method>", "Scoring method: weighted (default) or copeland", "weighted")
+  .option("--scoring <method>", "Scoring method: copeland (default) or weighted", "copeland")
   .option("--verbose", "Show detailed output from each agent")
   .action(async (promptArg: string | undefined, opts) => {
     const prompt = resolvePrompt(promptArg, opts.file);


### PR DESCRIPTION
## Summary
One-line change: default `--scoring` from `weighted` to `copeland`.

**Evidence (docs/scoring-evaluation.md, 21 runs):**
- Copeland = Borda: 86% agreement (two independent methods converge)
- Weighted disagrees with both ~40% (arbitrary weights)
- Copeland is scale-independent and Condorcet-consistent

## Change type
- [x] New feature

## Related issue
Closes #109

## How to test
```bash
thinktank run --help  # shows copeland as default
thinktank run "task" -n 3  # uses Copeland scoring
thinktank run "task" --scoring weighted  # old behavior still available
```

## Breaking changes
- [x] Default scoring method changed. Use `--scoring weighted` for previous behavior.

🤖 Generated with [Claude Code](https://claude.ai/code)