### PR TITLE
Create worktrees in parallel to reduce startup latency

### DIFF
--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -73,10 +73,14 @@ export async function run(opts: RunOptions): Promise<void> {
   };
   process.on("SIGINT", handleSigint);
 
-  for (let i = 1; i <= opts.attempts; i++) {
-    const path = await createWorktree(i);
-    worktrees.push({ id: i, path });
-    console.log(`    Agent #${i}: ${path}`);
+  const worktreeResults = await Promise.all(
+    Array.from({ length: opts.attempts }, (_, i) =>
+      createWorktree(i + 1).then((path) => ({ id: i + 1, path })),
+    ),
+  );
+  for (const wt of worktreeResults) {
+    worktrees.push(wt);
+    console.log(`    Agent #${wt.id}: ${wt.path}`);
   }
   console.log();
 


### PR DESCRIPTION
## Summary
- Replace sequential worktree creation with `Promise.all` — all worktrees created simultaneously
- Progress output batched after creation completes
- Safe because each worktree uses UUID branch names

**Generated by thinktank Opus** — 5 agents, 4/5 pass, Copeland: Agent #1 at +2.

## Change type
- [x] New feature

## Related issue
Closes #76

## How to test
```bash
npm test  # 131 tests pass
thinktank run "task" -n 5  # worktrees created faster
```

## Breaking changes
- [ ] This PR introduces breaking changes

🤖 Generated with [thinktank](https://github.com/that-github-user/thinktank) (Opus)