### PR TITLE
Bump default timeout to 600s and raise max to 1800s

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -57,8 +57,8 @@ program
     }
 
     const timeout = parseInt(opts.timeout, 10);
-    if (Number.isNaN(timeout) || timeout < 10 || timeout > 600) {
-      console.error("Error: --timeout must be a number between 10 and 600 seconds");
+    if (Number.isNaN(timeout) || timeout < 10 || timeout > 1800) {
+      console.error("Error: --timeout must be a number between 10 and 1800 seconds");
       process.exit(1);
     }
 

--- a/src/utils/config.test.ts
+++ b/src/utils/config.test.ts
@@ -37,7 +37,7 @@ describe("config", () => {
     it("has expected default values", () => {
       assert.equal(BUILT_IN_DEFAULTS.attempts, 3);
       assert.equal(BUILT_IN_DEFAULTS.model, "sonnet");
-      assert.equal(BUILT_IN_DEFAULTS.timeout, 300);
+      assert.equal(BUILT_IN_DEFAULTS.timeout, 600);
       assert.equal(BUILT_IN_DEFAULTS.runner, "claude-code");
       assert.equal(BUILT_IN_DEFAULTS.threshold, 0.3);
       assert.equal(BUILT_IN_DEFAULTS.testTimeout, 120);
@@ -103,7 +103,7 @@ describe("config", () => {
       const result = loadConfig();
       assert.equal(result.attempts, 7);
       assert.equal(result.model, "sonnet");
-      assert.equal(result.timeout, 300);
+      assert.equal(result.timeout, 600);
     });
   });
 
@@ -151,7 +151,7 @@ describe("config", () => {
     it("returns error for out-of-range timeout", () => {
       const error = setConfigValue("timeout", "5");
       assert.ok(error);
-      assert.match(error, /timeout must be an integer between 10 and 600/);
+      assert.match(error, /timeout must be an integer between 10 and 1800/);
     });
 
     it("returns error for out-of-range threshold", () => {

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -13,7 +13,7 @@ export interface Config {
 export const BUILT_IN_DEFAULTS: Config = {
   attempts: 3,
   model: "sonnet",
-  timeout: 300,
+  timeout: 600,
   runner: "claude-code",
   threshold: 0.3,
   testTimeout: 120,
@@ -49,8 +49,8 @@ function validateConfig(partial: Partial<Config>): string | null {
     }
   }
   if (partial.timeout !== undefined) {
-    if (!Number.isInteger(partial.timeout) || partial.timeout < 10 || partial.timeout > 600) {
-      return "timeout must be an integer between 10 and 600";
+    if (!Number.isInteger(partial.timeout) || partial.timeout < 10 || partial.timeout > 1800) {
+      return "timeout must be an integer between 10 and 1800";
     }
   }
   if (partial.testTimeout !== undefined) {


### PR DESCRIPTION
## Summary
- Default timeout: 300s → 600s (Opus agents timeout at 5 min on complex tasks)
- Max timeout: 600s → 1800s (30 min for large codebases)
- Updated config validation and tests

## Change type
- [x] Bug fix

## Breaking changes
- [x] Default timeout changed from 300s to 600s. Use `--timeout 300` for previous behavior.

🤖 Generated with [Claude Code](https://claude.ai/code)