### PR TITLE
Add pre-flight test run on main branch before spawning agents

### DIFF
--- a/src/commands/run.test.ts
+++ b/src/commands/run.test.ts
@@ -10,6 +10,7 @@ import {
   loadLatestResult,
   makeResultFilename,
   mergeRetryResults,
+  preflightTestRun,
   preflightValidation,
 } from "./run.js";
 
@@ -434,5 +435,36 @@ describe("checkDiskSpace", () => {
     if (result !== null) {
       assert.ok(result.includes("1000000 worktrees"));
     }
+  });
+});
+
+describe("preflightTestRun", () => {
+  it("returns null when test command succeeds", async () => {
+    const result = await preflightTestRun("node --version", process.cwd());
+    assert.equal(result, null);
+  });
+
+  it("returns warning when test command fails", async () => {
+    const result = await preflightTestRun("node --require ./nonexistent-module.js", process.cwd());
+    assert.ok(result);
+    assert.ok(result.includes("failed on the current branch"));
+    assert.ok(result.includes("test environment may already be broken"));
+  });
+
+  it("returns warning with output snippet when test produces output", async () => {
+    const result = await preflightTestRun("node --require ./nonexistent-module.js", process.cwd());
+    assert.ok(result);
+    assert.ok(result.includes("failed on the current branch"));
+  });
+
+  it("returns null for a passing test with output", async () => {
+    const result = await preflightTestRun("node --version", process.cwd());
+    assert.equal(result, null);
+  });
+
+  it("returns warning when command is not found", async () => {
+    const result = await preflightTestRun("nonexistent-command-xyz", process.cwd());
+    assert.ok(result);
+    assert.ok(result.includes("failed on the current branch"));
   });
 });

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -1,9 +1,11 @@
+import { execFile } from "node:child_process";
 import { mkdir, readFile, statfs, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { promisify } from "node:util";
 import { getDefaultRunner, getRunner } from "../runners/registry.js";
 import { analyzeConvergence, copelandRecommend, recommend } from "../scoring/convergence.js";
-import { runTests, validateTestCommand } from "../scoring/test-runner.js";
+import { parseTestCommand, runTests, validateTestCommand } from "../scoring/test-runner.js";
 import type { AgentResult, EnsembleResult, RunOptions } from "../types.js";
 import { displayApplyInstructions, displayHeader, displayResults } from "../utils/display.js";
 import {
@@ -13,6 +15,8 @@ import {
   getRepoRoot,
   removeWorktree,
 } from "../utils/git.js";
+
+const execFileAsync = promisify(execFile);
 
 function formatBytes(bytes: number): string {
   if (bytes >= 1024 * 1024 * 1024) {
@@ -163,6 +167,15 @@ export async function retry(opts: RunOptions): Promise<void> {
     process.exit(1);
   }
 
+  // Pre-flight test run: catch broken test environments before spawning agents
+  if (opts.testCmd) {
+    const repoRoot = await getRepoRoot();
+    const testWarning = await preflightTestRun(opts.testCmd, repoRoot);
+    if (testWarning) {
+      console.warn(`  ⚠ ${testWarning}`);
+    }
+  }
+
   // Clean up old worktrees
   await cleanupBranches().catch(() => {});
 
@@ -284,6 +297,34 @@ export async function retry(opts: RunOptions): Promise<void> {
   process.removeListener("SIGINT", handleSigint);
 }
 
+/**
+ * Run the test command once on the current branch before spawning agents.
+ * Returns a warning string if the tests fail, or null if they pass.
+ */
+export async function preflightTestRun(testCmd: string, repoRoot: string): Promise<string | null> {
+  const { cmd, args } = parseTestCommand(testCmd);
+  if (!cmd) return null;
+
+  try {
+    await execFileAsync(cmd, args, {
+      cwd: repoRoot,
+      timeout: 60_000,
+      shell: true,
+      env: { ...process.env, CI: "true" },
+    });
+    return null;
+  } catch (err: unknown) {
+    const e = err as { stdout?: string; stderr?: string; code?: number | string };
+    const output = ((e.stdout ?? "") + (e.stderr ?? "")).trim();
+    const snippet = output.length > 200 ? `${output.slice(0, 200)}...` : output;
+    return (
+      `Test command "${testCmd}" failed on the current branch before spawning agents. ` +
+      "Your test environment may already be broken.\n" +
+      (snippet ? `  Output: ${snippet}` : "")
+    );
+  }
+}
+
 export async function run(opts: RunOptions): Promise<void> {
   displayHeader(opts.prompt, opts.attempts, opts.model);
 
@@ -308,6 +349,15 @@ export async function run(opts: RunOptions): Promise<void> {
   if (preflightError) {
     console.error(`  ${preflightError}`);
     process.exit(1);
+  }
+
+  // Pre-flight test run: catch broken test environments before spawning agents
+  if (opts.testCmd) {
+    const repoRoot = await getRepoRoot();
+    const testWarning = await preflightTestRun(opts.testCmd, repoRoot);
+    if (testWarning) {
+      console.warn(`  ⚠ ${testWarning}`);
+    }
   }
 
   // Clean up any leftover worktrees/branches from previous runs


### PR DESCRIPTION
## Summary
- Run test command once on current branch before creating worktrees
- Warn if tests fail on main (broken test environment detection)
- Non-blocking: warns but continues
- 5 new tests

**Generated by thinktank Opus** — 5/5 agents pass, Copeland: #2 at +4.

## Change type
- [x] New feature

## Related issue
Closes #64

## How to test
```bash
npm test  # 220 tests pass
```

## Breaking changes
- [ ] This PR introduces breaking changes

🤖 Generated with [thinktank](https://github.com/that-github-user/thinktank) (Opus)