### PR TITLE
Prepare for npm publish: thinktank-ai package

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,10 +26,11 @@ Run N parallel Claude Code agents on the same task, then select the best result 
 ## Quick start
 
 ```bash
-# Install from source (npm package coming soon)
-git clone https://github.com/that-github-user/thinktank.git
-cd thinktank && npm install && npm run build
-npm link  # makes `thinktank` available globally
+# Install globally
+npm install -g thinktank-ai
+
+# Or run without installing
+npx thinktank-ai run "fix the authentication bypass"
 
 # Run 3 parallel agents on a task
 thinktank run "fix the authentication bypass"

--- a/package.json
+++ b/package.json
@@ -1,10 +1,18 @@
 {
-  "name": "thinktank",
+  "name": "thinktank-ai",
   "version": "0.1.0",
-  "description": "Ensemble AI coding — run N parallel Claude Code agents, select the best result via consensus + test execution",
+  "description": "Ensemble AI coding — run N parallel Claude Code agents, select the best result via Copeland pairwise scoring",
   "type": "module",
   "bin": {
     "thinktank": "./dist/cli.js"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/that-github-user/thinktank.git"
+  },
+  "homepage": "https://github.com/that-github-user/thinktank",
+  "bugs": {
+    "url": "https://github.com/that-github-user/thinktank/issues"
   },
   "scripts": {
     "build": "tsc",
@@ -26,7 +34,9 @@
   "author": "",
   "license": "MIT",
   "files": [
-    "dist",
+    "dist/**/*.js",
+    "dist/**/*.d.ts",
+    "!dist/**/*.test.*",
     "README.md",
     "LICENSE"
   ],


### PR DESCRIPTION
## Summary
- Package name: `thinktank-ai` (thinktank was taken on npm)
- CLI binary name stays `thinktank`
- Added repository/homepage/bugs metadata to package.json
- Excluded test files from published package (82KB → 35KB, 132 → 49 files)
- Updated README: `npm install -g thinktank-ai` / `npx thinktank-ai`
- Release workflow already in place from #28

**To publish after merge:**
1. Add `NPM_TOKEN` secret to GitHub repo settings
2. `git tag v0.1.0 && git push --tags`
3. Release workflow builds, tests, and publishes automatically

**This also resolves the dogfooding bug** (#136): once installed globally, thinktank runs from the npm install path, not from agent worktrees. Agents can't interfere with the tool's own infrastructure.

## Change type
- [x] New feature

## Related issue
Closes #139

## How to test
```bash
npm test        # 237 tests pass
npm pack --dry-run  # shows 49 files, 35KB
```

## Breaking changes
- [x] Package name changed from `thinktank` to `thinktank-ai`

🤖 Generated with [Claude Code](https://claude.ai/code)