### PR TITLE
Code quality: remove dead code, deduplicate padRight, clean exports

### DIFF
--- a/src/commands/clean.ts
+++ b/src/commands/clean.ts
@@ -6,7 +6,7 @@ import { cleanupBranches, getRepoRoot, removeWorktree } from "../utils/git.js";
 
 const exec = promisify(execFile);
 
-export interface CleanOptions {
+interface CleanOptions {
   all?: boolean;
 }
 

--- a/src/commands/compare.ts
+++ b/src/commands/compare.ts
@@ -4,7 +4,7 @@ import pc from "picocolors";
 import { diffSimilarity, parseDiff } from "../scoring/diff-parser.js";
 import type { AgentResult, EnsembleResult } from "../types.js";
 
-export interface CompareOptions {
+interface CompareOptions {
   agentA: number;
   agentB: number;
 }

--- a/src/commands/evaluate.ts
+++ b/src/commands/evaluate.ts
@@ -3,6 +3,7 @@ import { join } from "node:path";
 import pc from "picocolors";
 import { analyzeConvergence, copelandRecommend, recommend } from "../scoring/convergence.js";
 import type { EnsembleResult } from "../types.js";
+import { padRight } from "../utils/display.js";
 import { parseAndValidateResult } from "../utils/schema.js";
 
 interface RunEvaluation {
@@ -205,13 +206,6 @@ export async function evaluate(): Promise<void> {
   }
 
   console.log();
-}
-
-function padRight(str: string, len: number): string {
-  // biome-ignore lint/suspicious/noControlCharactersInRegex: intentional ANSI escape sequence matching
-  const stripped = str.replace(/\x1b\[[0-9;]*m/g, "");
-  const padding = Math.max(0, len - stripped.length);
-  return str + " ".repeat(padding);
 }
 
 function pct(n: number, total: number): string {

--- a/src/commands/list.test.ts
+++ b/src/commands/list.test.ts
@@ -1,14 +1,7 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 import type { EnsembleResult } from "../types.js";
-import { buildRunSummary, extractRunNumber } from "./list.js";
-
-describe("extractRunNumber", () => {
-  it("returns -1 (run numbers assigned by load order, not filename)", () => {
-    assert.equal(extractRunNumber("run-2026-03-28T05-58-48-564Z.json"), -1);
-    assert.equal(extractRunNumber("latest.json"), -1);
-  });
-});
+import { buildRunSummary } from "./list.js";
 
 function makeResult(overrides: Partial<EnsembleResult> = {}): EnsembleResult {
   return {

--- a/src/commands/list.ts
+++ b/src/commands/list.ts
@@ -14,11 +14,6 @@ export interface RunSummary {
   avgConvergence: number | null;
 }
 
-/** Run numbers are assigned by sort order (chronological), not embedded in filename */
-export function extractRunNumber(_filename: string): number {
-  return -1; // Assigned by loadAllRuns based on sort position
-}
-
 export function buildRunSummary(runNumber: number, result: EnsembleResult): RunSummary {
   const testPassRate =
     result.tests.length > 0

--- a/src/commands/stats.ts
+++ b/src/commands/stats.ts
@@ -4,7 +4,7 @@ import pc from "picocolors";
 import type { EnsembleResult } from "../types.js";
 import { parseAndValidateResult } from "../utils/schema.js";
 
-export interface StatsOptions {
+interface StatsOptions {
   model?: string;
   since?: string;
   until?: string;


### PR DESCRIPTION
## Summary
- Remove dead `extractRunNumber()` — always returned -1 (#130)
- Import `padRight` from display.ts instead of duplicating in evaluate.ts (#132)
- Make `CleanOptions`, `CompareOptions`, `StatsOptions` non-exported (#133)

## Change type
- [x] Refactor
- [x] Chore

## Related issue
Closes #130, #132, #133

## How to test
```bash
npm test  # 236 tests pass
```

## Breaking changes
- [ ] This PR introduces breaking changes

🤖 Generated with [Claude Code](https://claude.ai/code)