### PR TITLE
Fix schema backward compat: scoring and scores fields optional

### DIFF
--- a/src/utils/schema.test.ts
+++ b/src/utils/schema.test.ts
@@ -84,9 +84,15 @@ describe("validateResult", () => {
     assert.match(validateResult(result)!, /scoring/);
   });
 
-  it("rejects missing scoring", () => {
+  it("accepts missing scoring (backward compat — defaults to weighted)", () => {
     const result = makeValidResult();
     delete result.scoring;
+    assert.equal(validateResult(result), null);
+  });
+
+  it("rejects invalid scoring value", () => {
+    const result = makeValidResult();
+    result.scoring = "invalid";
     assert.match(validateResult(result)!, /scoring/);
   });
 
@@ -126,10 +132,10 @@ describe("validateResult", () => {
     assert.match(validateResult(result)!, /recommended/);
   });
 
-  it("rejects missing scores", () => {
+  it("accepts missing scores (backward compat)", () => {
     const result = makeValidResult();
     delete result.scores;
-    assert.match(validateResult(result)!, /scores/);
+    assert.equal(validateResult(result), null);
   });
 
   it("rejects non-array scores", () => {

--- a/src/utils/schema.ts
+++ b/src/utils/schema.ts
@@ -20,8 +20,8 @@ export function validateResult(data: unknown): string | null {
   if (typeof obj.timestamp !== "string") {
     return "missing or invalid field: timestamp (expected string)";
   }
-  if (obj.scoring !== "weighted" && obj.scoring !== "copeland") {
-    return 'missing or invalid field: scoring (expected "weighted" or "copeland")';
+  if (obj.scoring !== undefined && obj.scoring !== "weighted" && obj.scoring !== "copeland") {
+    return 'invalid field: scoring (expected "weighted", "copeland", or omitted)';
   }
   if (!Array.isArray(obj.agents)) {
     return "missing or invalid field: agents (expected array)";
@@ -35,8 +35,8 @@ export function validateResult(data: unknown): string | null {
   if (obj.recommended !== null && typeof obj.recommended !== "number") {
     return "missing or invalid field: recommended (expected number or null)";
   }
-  if (!Array.isArray(obj.scores)) {
-    return "missing or invalid field: scores (expected array)";
+  if (obj.scores !== undefined && !Array.isArray(obj.scores)) {
+    return "invalid field: scores (expected array or omitted)";
   }
 
   return null;


### PR DESCRIPTION
Make scoring and scores fields optional for old run files. Stats: 31→58 runs visible. 250 tests pass.