### PR TITLE
Fix README: add --no-timeout, --output-format diff, thinktank init

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,9 +143,14 @@ Run N parallel agents on a task.
 | `--threshold <number>` | Convergence clustering similarity threshold, 0.0–1.0 (default: 0.3) |
 | `--whitespace-insensitive` | Ignore whitespace in convergence comparison |
 | `--retry` | Re-run only failed/timed-out agents from the last run |
-| `--output-format <fmt>` | Output format: `text` (default) or `json` |
+| `--no-timeout` | Disable agent timeout entirely |
+| `--output-format <fmt>` | Output format: `text` (default), `json`, or `diff` |
 | `--no-color` | Disable colored output |
 | `--verbose` | Show detailed agent output |
+
+### `thinktank init`
+
+Set up thinktank in the current project — checks prerequisites and detects your test command.
 
 ### `thinktank apply`
 


### PR DESCRIPTION
## Summary
README fixes found by thinktank ensemble run (3/3 agents, 89% convergence):
- Add missing `--no-timeout` flag to run command table
- Update `--output-format` to include `diff` option
- Add `thinktank init` command section
- Remove duplicate init entry from agent output

## Change type
- [x] Documentation

## How to test
Read the README — verify flags match `thinktank run --help`.

## Breaking changes
- [ ] This PR introduces breaking changes

🤖 Found by [thinktank](https://github.com/that-github-user/thinktank) ensemble (3 Opus agents, 89% convergence)