### PR TITLE
Restore NPM_TOKEN in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,8 +36,10 @@ jobs:
       - name: Test
         run: npm test
 
-      - name: Publish to npm
+      - name: Publish to npm (trusted publishing via OIDC)
         run: npm publish --provenance --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2


### PR DESCRIPTION
npm OIDC is for provenance, not auth. Registry still needs NODE_AUTH_TOKEN.